### PR TITLE
Reordered install_github commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Getting Started
   ```r
   install.packages("devtools")
   library(devtools)
-  install_github("ohdsi/DatabaseConnector")
   install_github("ohdsi/SqlRender")
+  install_github("ohdsi/DatabaseConnector")
   install_github("ohdsi/Achilles")
   ```
   


### PR DESCRIPTION
Reordered install_github commands (SQLRender must come before DatabaseConnector)