### PR TITLE
Add docker usage alternative

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# A Docker container to run the OHDSI/Achilles analysis tool
+FROM r-base:3.1.2
+
+MAINTAINER Aaron Browne <brownea@email.chop.edu>
+
+# Remove Debain 'jessie' package pinning by r-base.
+RUN echo '' > /etc/apt/apt.conf.d/default
+
+# Install java and clean up.
+ENV JAVA_DEBIAN_VERSION 6b34-1.13.6-1
+RUN apt-get update && \
+    apt-get install -y \
+    libcurl4-openssl-dev \
+    openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
+    && rm -rf /var/lib/apt/lists/* \
+    && R CMD javareconf
+
+# Install Achilles requirements
+RUN install2.r --error \
+    devtools \
+    httr \
+    && installGithub.r \
+    OHDSI/SqlRender \
+    OHDSI/DatabaseConnector \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+
+# Configure workspace
+WORKDIR /opt/app
+ENV PATH /opt/app:$PATH
+VOLUME /opt/app/output
+
+# Add project files to container
+COPY . /opt/app/
+RUN chmod +x /opt/app/docker-run
+
+# Install Achilles from source
+RUN R COMMAND INSTALL /opt/app \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+
+# Define run script as default command
+CMD ["docker-run"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ Getting Started
   exportToJson(connectionDetails, "cdm4_inst", "results", "c:/myPath/AchillesExport")
   ```
 
+Getting Started with Docker
+===========================
+This is an alternative method for running Achilles that does not require R and Java installations, using a Docker container instead.
+
+1. Install [Docker](https://docs.docker.com/installation/) and [Docker Compose](https://docs.docker.com/compose/install/).
+
+2. Clone this repository with git (`git clone https://github.com/OHDSI/Achilles.git`) and make it your working directory (`cd Achilles`).
+
+3. Copy `env_vars.sample` to `env_vars` and fill in the variable definitions. The `ACHILLES_DB_URI` should be formatted as `<dbms>://<username>:<password>@<host>/<schema>`.
+
+4. Copy `docker-compose.yml.sample` to `docker-compose.yml` and fill in the data output directory.
+
+5. Build the docker image with `docker-compose build`.
+
+6. Run Achilles in the background with `docker-compose run -d achilles`.
+
+
 License
 =======
 Achilles is licensed under Apache License 2.0

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -1,0 +1,6 @@
+achilles:
+    build: .
+    env_file:
+        - env_vars
+    volumes:
+        - <data output directory>:/opt/app/output:rw

--- a/docker-run
+++ b/docker-run
@@ -1,0 +1,47 @@
+#!/usr/bin/Rscript
+
+# Load Achilles and httr.
+library(Achilles)
+library(httr)
+
+# Get passed environment variables.
+env_var_names <- list("ACHILLES_SITE", "ACHILLES_DB_URI",
+                      "ACHILLES_CDM_SCHEMA", "ACHILLES_RES_SCHEMA",
+                      "ACHILLES_OUTPUT_BASE")
+env_vars <- Sys.getenv(env_var_names, unset=NA)
+
+# Replace unset environement variables with defaults.
+default_vars <- list("DefaultSite", "postgresql://localhost/postgres",
+                     "public", "public", "./output")
+env_vars[is.na(env_vars)] <- default_vars[is.na(env_vars)]
+
+# Create name to tag results and output path from ACHILLES_SITE and timestamp
+current_datetime <- strftime(Sys.time(), format="%Y-%m-%dT%H:%M:%S")
+src_name <- paste(env_vars$ACHILLES_SITE, current_datetime, sep=" ")
+output_path <- paste(env_vars$ACHILLES_OUTPUT_BASE, env_vars$ACHILLES_SITE,
+                     current_datetime, sep="/")
+dir.create(output_path, showWarnings=FALSE, recursive=TRUE, mode=0770)
+
+# Parse DB URI into pieces.
+db_conf <- parse_url(env_vars$ACHILLES_DB_URI)
+
+# Some connection packages need the database on the server argument.
+server <- paste(db_conf$hostname, db_conf$path, sep="/")
+
+# Create connection details using DatabaseConnector utility.
+connectionDetails <- createConnectionDetails(
+    dbms=db_conf$scheme, user=db_conf$username, password=db_conf$password,
+    server=server, schema=db_conf$path, port=db_conf$port
+)
+
+# Run Achilles report and generate data in the results schema.
+achillesResults <- achilles(
+    connectionDetails, cdmSchema=env_vars$ACHILLES_CDM_SCHEMA,
+    resultsSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name
+)
+
+# Export Achilles results to output path in JSON format.
+exportToJson(
+    connectionDetails, cdmSchema=env_vars$ACHILLES_CDM_SCHEMA,
+    resultsSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path
+)

--- a/env_vars.sample
+++ b/env_vars.sample
@@ -1,0 +1,4 @@
+ACHILLES_SITE=<site_name>
+ACHILLES_DB_URI=<db_uri>
+ACHILLES_CDM_SCHEMA=<cdm_schema>
+ACHILLES_RES_SCHEMA=<results_schema>


### PR DESCRIPTION
A Dockerfile is added that starts from a standard R image,
installs all Achilles requirements, installs Achilles from source,
and defines the (new) docker-run script as the default command.
Sample docker-compose and env_var files are added and instructions for
the entire setup and run process, including creating live versions of
those files, are added to the README.

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>