### PR TITLE
Squash bugs in Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ MAINTAINER Aaron Browne <brownea@email.chop.edu>
 RUN echo '' > /etc/apt/apt.conf.d/default
 
 # Install java and clean up.
-ENV JAVA_DEBIAN_VERSION 6b34-1.13.6-1
 RUN apt-get update && \
     apt-get install -y \
+    libssl-dev \
     libcurl4-openssl-dev \
-    openjdk-6-jdk="$JAVA_DEBIAN_VERSION" \
+    libxml2-dev \
+    openjdk-6-jdk \
     && rm -rf /var/lib/apt/lists/* \
     && R CMD javareconf
 
@@ -19,6 +20,7 @@ RUN apt-get update && \
 RUN install2.r --error \
     devtools \
     httr \
+    rjson \
     && installGithub.r \
     OHDSI/SqlRender \
     OHDSI/DatabaseConnector \
@@ -34,7 +36,7 @@ COPY . /opt/app/
 RUN chmod +x /opt/app/docker-run
 
 # Install Achilles from source
-RUN R COMMAND INSTALL /opt/app \
+RUN R CMD INSTALL /opt/app \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Define run script as default command

--- a/docker-run
+++ b/docker-run
@@ -20,7 +20,7 @@ current_datetime <- strftime(Sys.time(), format="%Y-%m-%dT%H:%M:%S")
 src_name <- paste(env_vars$ACHILLES_SITE, current_datetime, sep=" ")
 output_path <- paste(env_vars$ACHILLES_OUTPUT_BASE, env_vars$ACHILLES_SITE,
                      current_datetime, sep="/")
-dir.create(output_path, showWarnings=FALSE, recursive=TRUE, mode=0770)
+dir.create(output_path, showWarnings=FALSE, recursive=TRUE, mode="0755")
 
 # Parse DB URI into pieces.
 db_conf <- parse_url(env_vars$ACHILLES_DB_URI)
@@ -36,12 +36,12 @@ connectionDetails <- createConnectionDetails(
 
 # Run Achilles report and generate data in the results schema.
 achillesResults <- achilles(
-    connectionDetails, cdmSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name
+    connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name
 )
 
 # Export Achilles results to output path in JSON format.
 exportToJson(
-    connectionDetails, cdmSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path
+    connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path
 )


### PR DESCRIPTION
Remove specification of openjdk version because old versions are
apparently not available on the debian repos and version scoping doesn't
seem possible given the version string format.

Add installation of libssl-dev and libxml2-dev to the OS and rjson to R.
These must be new dependencies, because the installation was working
previously.

Fix Achilles installation typo (`R COMMAND INSTALL` to `R CMD INSTALL`).

Fix permissions of created output dir to match Achilles-created dir
permissions ("0755").

Update `achilles` and `exportToJson` function call signatures to use
`cdmDatabaseSchema` instead of outdated `cdmSchema` (and corresponding
`results...`) arguments.

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>