### PR TITLE
Changed the README to include cdmVersion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Achilles
 ========
  
-Automated Characterization of Health Information at Large-scale Longitudinal Evidence Systems (ACHILLES) - descriptive statistics about a OMOP CDM v4 database
+Automated Characterization of Health Information at Large-scale Longitudinal Evidence Systems (ACHILLES) - descriptive statistics about a OMOP CDM v4/v5 database
 
 Getting Started
 ===============
 (Please review the [Achilles Wiki](https://github.com/OHDSI/Achilles/wiki/Additional-instructions-for-Linux) for specific details for Linux)
 
-1. Make sure you have your data in the [OMOP CDM v4 format](http://omop.org/cdm).
+1. Make sure you have your data in the [OMOP CDM v4/v5 format](http://omop.org/cdm).
 
 2. Make sure that you have Java installed. If you don't have Java already intalled on your computed (on most computers it already is installed), go to [java.com](http://java.com) to get the latest version.  (If you have trouble building with rJava below, be sure on Windows that your Path variable includes the path to jvm.dll (Windows Button --> type "path" --> Edit Environmental Variables --> Edit PATH variable, add to end ;C:/Program Files/Java/jre/bin/server) or wherever it is on your system.)
 
@@ -26,17 +26,18 @@ Getting Started
   ```r
   library(Achilles)
   connectionDetails <- createConnectionDetails(dbms="sql server", server="server.com")
-  achillesResults <- achilles(connectionDetails, "cdm4_inst", "results")
+  achillesResults <- achilles(connectionDetails, "cdm4_inst", "results", cdmVersion = "cdm version")
   ```
   "cdm4_inst" and "results" are the names of the schemas holding the CDM data and target results respectively. See the [DatabaseConnector](https://github.com/OHDSI/DatabaseConnector) package for details on settings the connection details for your database, for example by typing
   ```r
   ?createConnectionDetails
   ```
   Currently "sql server", "oracle", "postgresql", and "redshift" are supported as dbms.
+  "cdmVersion" can be either 4 or 5.
 
 5. To use [AchillesWeb](https://github.com/OHDSI/AchillesWeb) to explore the Achilles statistics, you must first export the statistics to JSON files:
   ```r
-  exportToJson(connectionDetails, "cdm4_inst", "results", "c:/myPath/AchillesExport")
+  exportToJson(connectionDetails, "cdm4_inst", "results", "c:/myPath/AchillesExport", cdmVersion = "cdm version")
   ```
 
 Getting Started with Docker


### PR DESCRIPTION
Hi,

I just updated the README to include the cdmVersion parameter while running Achilles. For cdm v5, the user needs to specify this parameter or Achilles doesn't run successfully.

Best,
Aarti