### PR TITLE
V5 Treemap - use domain_id

### DIFF
--- a/inst/sql/sql_server/export_v5/condition/sqlConditionTreemap.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlConditionTreemap.sql
@@ -16,9 +16,9 @@ from (select * from ACHILLES_results where analysis_id = 400) ar1
 			soc.concept_name as soc_concept_name
 		from	
 		(
-		select concept_id, concept_name
-		from @cdm_database_schema.concept
-		where vocabulary_id = 'SNOMED'
+			select concept_id, concept_name
+			from @cdm_database_schema.concept
+			where domain_id = 'Condition'
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
@@ -27,7 +27,7 @@ from (select * from ACHILLES_results where analysis_id = 400) ar1
 			inner join 
 			@cdm_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 'SNOMED'
+			and c1.domain_id = 'Condition'
 			and ca1.min_levels_of_separation = 1
 			inner join 
 			@cdm_database_schema.concept c2
@@ -90,9 +90,6 @@ from (select * from ACHILLES_results where analysis_id = 400) ar1
 
 		left join @cdm_database_schema.concept soc
 		 on hlgt_to_soc.soc_concept_id = soc.concept_id
-
-
-
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR)
 	,

--- a/inst/sql/sql_server/export_v5/conditionera/sqlConditionEraTreemap.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlConditionEraTreemap.sql
@@ -17,9 +17,9 @@ from (select * from ACHILLES_results where analysis_id = 1000) ar1
 			soc.concept_name as soc_concept_name
 		from	
 		(
-		select concept_id, concept_name
-		from @cdm_database_schema.concept
-		where vocabulary_id = 'SNOMED'
+			select concept_id, concept_name
+			from @cdm_database_schema.concept
+			where domain_id = 'Condition'
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
@@ -28,7 +28,7 @@ from (select * from ACHILLES_results where analysis_id = 1000) ar1
 			inner join 
 			@cdm_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 'SNOMED'
+			and c1.domain_id = 'Condition'
 			and ca1.min_levels_of_separation = 1
 			inner join 
 			@cdm_database_schema.concept c2

--- a/inst/sql/sql_server/export_v5/drug/sqlDrugTreemap.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlDrugTreemap.sql
@@ -28,10 +28,10 @@ from (select * from ACHILLES_results where analysis_id = 700) ar1
 		from @cdm_database_schema.concept c1
 			inner join @cdm_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 'RxNorm'
+			and c1.domain_id = 'Drug'
 			inner join @cdm_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
-			and c2.vocabulary_id = 'RxNorm'
+			and c2.domain_id = 'Drug'
 			and c2.concept_class_id = 'Ingredient'
 		) rxnorm
 		left join
@@ -41,7 +41,7 @@ from (select * from ACHILLES_results where analysis_id = 700) ar1
 			inner join 
 			@cdm_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 'RxNorm'
+			and c1.domain_id = 'Drug'
 			and c1.concept_class_id = 'Ingredient'
 			inner join 
 			@cdm_database_schema.concept c2

--- a/inst/sql/sql_server/export_v5/drugera/sqlDrugEraTreemap.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlDrugEraTreemap.sql
@@ -24,7 +24,7 @@ from (select * from ACHILLES_results where analysis_id = 900) ar1
 		from 
 			@cdm_database_schema.concept c2
 			where
-			c2.vocabulary_id = 'RxNorm'
+			c2.domain_id = 'Drug'
 			and c2.concept_class_id = 'Ingredient'
 		) rxnorm
 		left join
@@ -34,7 +34,7 @@ from (select * from ACHILLES_results where analysis_id = 900) ar1
 			inner join 
 			@cdm_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
-			and c1.vocabulary_id = 'RxNorm'
+			and c1.domain_id = 'Drug'
 			and c1.concept_class_id = 'Ingredient'
 			inner join 
 			@cdm_database_schema.concept c2

--- a/inst/sql/sql_server/export_v5/observation/sqlObservationTreemap.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlObservationTreemap.sql
@@ -15,9 +15,9 @@ from (select * from ACHILLES_results where analysis_id = 800) ar1
 		select obs.concept_id, obs.concept_name, max(c1.concept_name) as level1_concept_name, max(c2.concept_name) as level2_concept_name, max(c3.concept_name) as level3_concept_name
 		from
 		(
-		select concept_id, concept_name
-		from @cdm_database_schema.concept
-		where vocabulary_id = 'LOINC'
+			select concept_id, concept_name
+			from @cdm_database_schema.concept
+			where domain_id = 'Observation'
 		) obs left join @cdm_database_schema.concept_ancestor ca1 on obs.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
 		left join @cdm_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
 		left join @cdm_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1

--- a/inst/sql/sql_server/export_v5/procedure/sqlProcedureTreemap.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlProcedureTreemap.sql
@@ -19,17 +19,13 @@ from (select * from ACHILLES_results where analysis_id = 600) ar1
 		max(proc_hierarchy.os1_concept_name) as level4_concept_name
 	 from
 		(
-		select c1.concept_id, 
-			v1.vocabulary_name + ' ' + c1.concept_code + ': ' + c1.concept_name as proc_concept_name
-		from @cdm_database_schema.concept c1
-			inner join @cdm_database_schema.vocabulary v1
-			on c1.vocabulary_id = v1.vocabulary_id
-		where (
-			c1.vocabulary_id in ('ICD9Proc', 'HCPCS','CPT4')
-			or (c1.vocabulary_id = 'SNOMED' and c1.concept_class_id = 'Procedure')
-			)
+			select c1.concept_id, 
+				v1.vocabulary_name + ' ' + c1.concept_code + ': ' + c1.concept_name as proc_concept_name
+			from @cdm_database_schema.concept c1
+				inner join @cdm_database_schema.vocabulary v1
+				on c1.vocabulary_id = v1.vocabulary_id
+			WHERE c1.domain_id = 'Procedure'
 		) procs
-
 	left join
 		(select ca0.DESCENDANT_CONCEPT_ID, max(ca0.ancestor_concept_id) as ancestor_concept_id
 		from @cdm_database_schema.concept_ancestor ca0


### PR DESCRIPTION
Resolves Issue #81. Please note that vocabulary_id is still referenced in these scripts in order to build out hierarchies to ATC and MedDRA.