### PR TITLE
Vocab schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .Rproj.user
 .Rhistory
 .RData
+env_vars
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN echo '' > /etc/apt/apt.conf.d/default
 # Install java and clean up.
 RUN apt-get update && \
     apt-get install -y \
-    libssl-dev \
     libcurl4-openssl-dev \
+    libssl-dev \
     libxml2-dev \
     openjdk-7-jdk \
     && rm -rf /var/lib/apt/lists/* \

--- a/R/exportToJson.R
+++ b/R/exportToJson.R
@@ -74,10 +74,11 @@ showReportTypes <- function()
 #' 
 #' 
 #' @param connectionDetails  An R object of type ConnectionDetail (details for the function that contains server info, database type, optionally username/password, port)
-#' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
+#' @param cdmDatabaseSchema      Name of the database schema that contains the OMOP CDM.
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
 #' @param reports       A character vector listing the set of reports to generate. Default is all reports. 
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' See \code{data(allReports)} for a list of all report types
 #' 
 #' @return none 
@@ -86,7 +87,7 @@ showReportTypes <- function()
 #'   exportToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), reports = allReports, cdmVersion = "4")
+exportToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), reports = allReports, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   start <- Sys.time()
   if (missing(resultsDatabaseSchema))
@@ -102,70 +103,70 @@ exportToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseS
   
   if ("CONDITION" %in% reports)
   {
-    generateConditionTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)  
-    generateConditionReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateConditionTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)  
+    generateConditionReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("CONDITION_ERA" %in% reports)
   {
-    generateConditionEraTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateConditionEraReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateConditionEraTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateConditionEraReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("DATA_DENSITY" %in% reports)
-    generateDataDensityReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateDataDensityReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   
   if ("DEATH" %in% reports)
   {
-    generateDeathReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateDeathReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("DRUG_ERA" %in% reports)
   {
-    generateDrugEraTreemap(conn,connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateDrugEraReports(conn,connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateDrugEraTreemap(conn,connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateDrugEraReports(conn,connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("DRUG" %in% reports)
   {
-    generateDrugTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)  
-    generateDrugReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateDrugTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)  
+    generateDrugReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("HEEL" %in% reports)
   {
-    generateAchillesHeelReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateAchillesHeelReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ( ("MEASUREMENT" %in% reports) & (cdmVersion != "4"))
   {
-    generateMeasurementTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateMeasurementReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateMeasurementTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateMeasurementReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   
   if ("OBSERVATION" %in% reports)
   {  
-    generateObservationTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateObservationReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateObservationTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateObservationReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("OBSERVATION_PERIOD" %in% reports)  
-    generateObservationPeriodReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateObservationPeriodReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   
   if ("PERSON" %in% reports)    
-    generatePersonReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generatePersonReport(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   
   if ("PROCEDURE" %in% reports)
   {
-    generateProcedureTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateProcedureReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateProcedureTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateProcedureReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   if ("VISIT" %in% reports)
   {  
-    generateVisitTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
-    generateVisitReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion)
+    generateVisitTreemap(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
+    generateVisitReports(conn, connectionDetails$dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion, vocabDatabaseSchema)
   }
   
   # dashboard is always last
@@ -194,6 +195,7 @@ exportToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseS
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -201,9 +203,9 @@ exportToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseS
 #'   exportConditionToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportConditionToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportConditionToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("CONDITION"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("CONDITION"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportConditionEraToJson
@@ -219,6 +221,7 @@ exportConditionToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -226,9 +229,9 @@ exportConditionToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #'   exportConditionEraToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportConditionEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportConditionEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("CONDITION_ERA"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("CONDITION_ERA"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportDashboardToJson
@@ -245,6 +248,7 @@ exportConditionEraToJson <- function (connectionDetails, cdmDatabaseSchema, resu
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -252,9 +256,9 @@ exportConditionEraToJson <- function (connectionDetails, cdmDatabaseSchema, resu
 #'   exportDashboardToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportDashboardToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportDashboardToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DASHBOARD"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DASHBOARD"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportDataDensityToJson
@@ -270,6 +274,7 @@ exportDashboardToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -277,9 +282,9 @@ exportDashboardToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #'   exportDataDensityToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportDataDensityToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportDataDensityToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DATA_DENSITY"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DATA_DENSITY"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportDeathToJson
@@ -295,6 +300,7 @@ exportDataDensityToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -302,9 +308,9 @@ exportDataDensityToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #'   exportDeathToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportDeathToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportDeathToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DEATH"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DEATH"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportDrugToJson
@@ -320,6 +326,7 @@ exportDeathToJson <- function (connectionDetails, cdmDatabaseSchema, resultsData
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -327,9 +334,9 @@ exportDeathToJson <- function (connectionDetails, cdmDatabaseSchema, resultsData
 #'   exportDrugToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportDrugToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportDrugToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DRUG"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DRUG"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportDrugEraToJson
@@ -345,6 +352,7 @@ exportDrugToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatab
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -352,9 +360,9 @@ exportDrugToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatab
 #'   exportDrugEraToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportDrugEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportDrugEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DRUG_ERA"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("DRUG_ERA"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportHeelToJson
@@ -370,6 +378,7 @@ exportDrugEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDa
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -377,9 +386,9 @@ exportDrugEraToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDa
 #'   exportHeelToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportHeelToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportHeelToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("HEEL"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("HEEL"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportMeasurementToJson
@@ -395,6 +404,7 @@ exportHeelToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatab
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -402,9 +412,9 @@ exportHeelToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatab
 #'   exportMeasurementToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportMeasurementToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportMeasurementToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("MEASUREMENT"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("MEASUREMENT"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportObservationToJson
@@ -420,6 +430,7 @@ exportMeasurementToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -427,9 +438,9 @@ exportMeasurementToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #'   exportObservationToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportObservationToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportObservationToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("OBSERVATION"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("OBSERVATION"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportObservationPeriodToJson
@@ -445,6 +456,7 @@ exportObservationToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -452,9 +464,9 @@ exportObservationToJson <- function (connectionDetails, cdmDatabaseSchema, resul
 #'   exportObservationPeriodToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportObservationPeriodToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportObservationPeriodToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("OBSERVATION_PERIOD"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("OBSERVATION_PERIOD"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportPersonToJson
@@ -470,6 +482,7 @@ exportObservationPeriodToJson <- function (connectionDetails, cdmDatabaseSchema,
 #' @param cdmDatabaseSchema    	Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema			Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -477,9 +490,9 @@ exportObservationPeriodToJson <- function (connectionDetails, cdmDatabaseSchema,
 #'   exportPersonToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportPersonToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportPersonToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("PERSON"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("PERSON"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportProcedureToJson
@@ -495,6 +508,7 @@ exportPersonToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDat
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -502,9 +516,9 @@ exportPersonToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDat
 #'   exportProcedureToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportProcedureToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportProcedureToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("PROCEDURE"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("PROCEDURE"), cdmVersion, vocabDatabaseSchema)  
 }
 
 #' @title exportVisitToJson
@@ -520,6 +534,7 @@ exportProcedureToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #' @param cdmDatabaseSchema      Name of the database schema that contains the vocabulary files
 #' @param resultsDatabaseSchema  		Name of the database schema that contains the Achilles analysis files. Default is cdmDatabaseSchema
 #' @param outputPath		A folder location to save the JSON files. Default is current working folder
+#' @param vocabDatabaseSchema		string name of database schema that contains OMOP Vocabulary. Default is cdmDatabaseSchema. On SQL Server, this should specifiy both the database and the schema, so for example 'results.dbo'.
 #' 
 #' @return none 
 #' @examples \dontrun{
@@ -527,9 +542,9 @@ exportProcedureToJson <- function (connectionDetails, cdmDatabaseSchema, results
 #'   exportVisitToJson(connectionDetails, cdmDatabaseSchema="cdm4_sim", outputPath="your/output/path")
 #' }
 #' @export
-exportVisitToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4")
+exportVisitToJson <- function (connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath = getwd(), cdmVersion="4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
-  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("VISIT"), cdmVersion)  
+  exportToJson(connectionDetails, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, reports = c("VISIT"), cdmVersion, vocabDatabaseSchema)  
 }
 
 addCdmVersionPath <- function(sqlFilename,cdmVersion){
@@ -543,7 +558,7 @@ addCdmVersionPath <- function(sqlFilename,cdmVersion){
   paste(sqlFolder,sqlFilename,sep="")
 }
 
-generateAchillesHeelReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateAchillesHeelReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating achilles heel report")
   output <- {}
   
@@ -551,7 +566,8 @@ generateAchillesHeelReport <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                               packageName = "Achilles",
                                               dbms = dbms,
                                               cdm_database_schema = cdmDatabaseSchema,
-					      results_database_schema = resultsDatabaseSchema
+                                              results_database_schema = resultsDatabaseSchema,
+                                              vocab_database_schema = vocabDatabaseSchema
   )  
   
   output$MESSAGES <- querySql(conn,queryAchillesHeel)
@@ -559,7 +575,7 @@ generateAchillesHeelReport <- function(conn, dbms, cdmDatabaseSchema, resultsDat
   write(jsonOutput, file=paste(outputPath, "/achillesheel.json", sep=""))  
 }
 
-generateDrugEraTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateDrugEraTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating drug era treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -568,7 +584,8 @@ generateDrugEraTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabase
                                                 packageName = "Achilles",
                                                 dbms = dbms,
                                                 cdm_database_schema = cdmDatabaseSchema,
-						results_database_schema = resultsDatabaseSchema
+                                                results_database_schema = resultsDatabaseSchema,
+                                                vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataDrugEraTreemap <- querySql(conn,queryDrugEraTreemap) 
@@ -580,7 +597,7 @@ generateDrugEraTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabase
   close(progressBar)  
 }
 
-generateDrugTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateDrugTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating drug treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -589,7 +606,8 @@ generateDrugTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSch
                                              packageName = "Achilles",
                                              dbms = dbms,
                                              cdm_database_schema = cdmDatabaseSchema,
-					     results_database_schema = resultsDatabaseSchema
+                                             results_database_schema = resultsDatabaseSchema,
+                                             vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataDrugTreemap <- querySql(conn,queryDrugTreemap) 
@@ -601,7 +619,7 @@ generateDrugTreemap <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSch
   close(progressBar)  
 }
 
-generateConditionTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateConditionTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating condition treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -610,7 +628,8 @@ generateConditionTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataConditionTreemap <- querySql(conn,queryConditionTreemap) 
@@ -622,7 +641,7 @@ generateConditionTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
   close(progressBar)
 }
 
-generateConditionEraTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateConditionEraTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating condition era treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -631,7 +650,8 @@ generateConditionEraTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDa
                                                      packageName = "Achilles",
                                                      dbms = dbms,
                                                      cdm_database_schema = cdmDatabaseSchema,
-						     results_database_schema = resultsDatabaseSchema
+                                                     results_database_schema = resultsDatabaseSchema,
+                                                     vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataConditionEraTreemap <- querySql(conn,queryConditionEraTreemap) 
@@ -643,7 +663,7 @@ generateConditionEraTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDa
   close(progressBar)
 }
 
-generateConditionReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateConditionReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating condition reports")
   
   treemapFile <- file.path(outputPath,"condition_treemap.json")
@@ -672,28 +692,32 @@ generateConditionReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/condition/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryConditionsByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/condition/sqlConditionsByType.sql",cdmVersion),
                                                   packageName = "Achilles",
                                                   dbms = dbms,
                                                   cdm_database_schema = cdmDatabaseSchema,
-						  results_database_schema = resultsDatabaseSchema
+                                                  results_database_schema = resultsDatabaseSchema,
+                                                  vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstDiagnosis <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/condition/sqlAgeAtFirstDiagnosis.sql",cdmVersion),
                                                      packageName = "Achilles",
                                                      dbms = dbms,
                                                      cdm_database_schema = cdmDatabaseSchema,
-						     results_database_schema = resultsDatabaseSchema
+                                                     results_database_schema = resultsDatabaseSchema,
+                                                     vocab_database_schema = vocabDatabaseSchema
   )
   
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -725,7 +749,7 @@ generateConditionReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
   close(progressBar)
 }
 
-generateConditionEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateConditionEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating condition era reports")
   
   treemapFile <- file.path(outputPath,"conditionera_treemap.json")
@@ -753,28 +777,32 @@ generateConditionEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDa
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/conditionera/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstDiagnosis <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/conditionera/sqlAgeAtFirstDiagnosis.sql",cdmVersion),
                                                      packageName = "Achilles",
                                                      dbms = dbms,
                                                      cdm_database_schema = cdmDatabaseSchema,
-						     results_database_schema = resultsDatabaseSchema
+                                                     results_database_schema = resultsDatabaseSchema,
+                                                     vocab_database_schema = vocabDatabaseSchema
   )
   
   queryLengthOfEra <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/conditionera/sqlLengthOfEra.sql",cdmVersion),
                                              packageName = "Achilles",
                                              dbms = dbms,
                                              cdm_database_schema = cdmDatabaseSchema,
-					     results_database_schema = resultsDatabaseSchema
+                                             results_database_schema = resultsDatabaseSchema,
+                                             vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -806,7 +834,7 @@ generateConditionEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDa
   close(progressBar)
 }
 
-generateDrugEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateDrugEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating drug era reports")
   
   
@@ -835,28 +863,32 @@ generateDrugEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabas
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByGenderAgeYear <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drugera/sqlPrevalenceByGenderAgeYear.sql",cdmVersion),
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drugera/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryLengthOfEra <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drugera/sqlLengthOfEra.sql",cdmVersion),
                                              packageName = "Achilles",
                                              dbms = dbms,
                                              cdm_database_schema = cdmDatabaseSchema,
-					     results_database_schema = resultsDatabaseSchema
+                                             results_database_schema = resultsDatabaseSchema,
+                                             vocab_database_schema = vocabDatabaseSchema
   )
   
   dataAgeAtFirstExposure <- querySql(conn,queryAgeAtFirstExposure) 
@@ -888,7 +920,7 @@ generateDrugEraReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabas
   close(progressBar)
 }
 
-generateDrugReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateDrugReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating drug reports")
   
   treemapFile <- file.path(outputPath,"drug_treemap.json")
@@ -915,49 +947,56 @@ generateDrugReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSc
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   queryDaysSupplyDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlDaysSupplyDistribution.sql",cdmVersion),
                                                         packageName = "Achilles",
                                                         dbms = dbms,
                                                         cdm_database_schema = cdmDatabaseSchema,
-							results_database_schema = resultsDatabaseSchema
+                                                        results_database_schema = resultsDatabaseSchema,
+                                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   queryDrugsByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlDrugsByType.sql",cdmVersion),
                                              packageName = "Achilles",
                                              dbms = dbms,
                                              cdm_database_schema = cdmDatabaseSchema,
-					     results_database_schema = resultsDatabaseSchema
+                                             results_database_schema = resultsDatabaseSchema,
+                                             vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByGenderAgeYear <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlPrevalenceByGenderAgeYear.sql",cdmVersion),
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryQuantityDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlQuantityDistribution.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   queryRefillsDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/drug/sqlRefillsDistribution.sql",cdmVersion),
                                                      packageName = "Achilles",
                                                      dbms = dbms,
                                                      cdm_database_schema = cdmDatabaseSchema,
-						     results_database_schema = resultsDatabaseSchema
+                                                     results_database_schema = resultsDatabaseSchema,
+                                                     vocab_database_schema = vocabDatabaseSchema
   )
   
   dataAgeAtFirstExposure <- querySql(conn,queryAgeAtFirstExposure) 
@@ -995,7 +1034,7 @@ generateDrugReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSc
   close(progressBar)
 }
 
-generateProcedureTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateProcedureTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating procedure treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -1004,7 +1043,8 @@ generateProcedureTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
                                                   packageName = "Achilles",
                                                   dbms = dbms,
                                                   cdm_database_schema = cdmDatabaseSchema,
-						  results_database_schema = resultsDatabaseSchema
+                                                  results_database_schema = resultsDatabaseSchema,
+                                                  vocab_database_schema = vocabDatabaseSchema
   )  
   
   dataProcedureTreemap <- querySql(conn,queryProcedureTreemap) 
@@ -1016,7 +1056,7 @@ generateProcedureTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
   close(progressBar)
 }
 
-generateProcedureReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateProcedureReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating procedure reports")
   
   treemapFile <- file.path(outputPath,"procedure_treemap.json")
@@ -1044,28 +1084,32 @@ generateProcedureReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/procedure/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryProceduresByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/procedure/sqlProceduresByType.sql",cdmVersion),
                                                   packageName = "Achilles",
                                                   dbms = dbms,
                                                   cdm_database_schema = cdmDatabaseSchema,
-						  results_database_schema = resultsDatabaseSchema
+                                                  results_database_schema = resultsDatabaseSchema,
+                                                  vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstOccurrence <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/procedure/sqlAgeAtFirstOccurrence.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -1096,7 +1140,7 @@ generateProcedureReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
   close(progressBar)
 }
 
-generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4")
+generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   writeLines("Generating person reports")
   progressBar <- txtProgressBar(max=7,style=3)
@@ -1112,7 +1156,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   personSummaryData <- querySql(conn,renderedSql)
@@ -1130,7 +1175,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   genderData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1147,7 +1193,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   raceData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1164,7 +1211,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   ethnicityData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1182,7 +1230,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   birthYearStats <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1197,7 +1246,8 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   birthYearData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1216,7 +1266,7 @@ generatePersonReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
   close(progressBar)
 }
 
-generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4")
+generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   writeLines("Generating observation period reports")
   progressBar <- txtProgressBar(max=11,style=3)
@@ -1240,7 +1290,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   ageAtFirstObservationData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1257,7 +1308,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   ageByGenderData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1275,7 +1327,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   observationLengthStats <- querySql(conn,renderedSql)
@@ -1290,7 +1343,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   observationLengthData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1309,7 +1363,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   cumulativeDurationData <- querySql(conn,renderedSql)
@@ -1326,7 +1381,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   opLengthByGenderData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1342,7 +1398,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   opLengthByAgeData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1359,7 +1416,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   observedByYearStats <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1373,7 +1431,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   observedByYearData <- querySql(conn,renderedSql)
@@ -1394,7 +1453,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   observedByMonth <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1411,7 +1471,8 @@ generateObservationPeriodReport <- function(conn, dbms, cdmDatabaseSchema, resul
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )
   personPeriodsData <- querySql(conn,renderedSql)
   progress = progress + 1
@@ -1459,7 +1520,7 @@ generateDashboardReport <- function(outputPath)
   close(progressBar)
 }
 
-generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4")
+generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   writeLines("Generating data density reports")
   progressBar <- txtProgressBar(max=3,style=3)
@@ -1476,7 +1537,8 @@ generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatab
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   totalRecordsData <- querySql(conn,renderedSql)
@@ -1494,7 +1556,8 @@ generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatab
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   recordsPerPerson <- querySql(conn,renderedSql)
@@ -1511,7 +1574,8 @@ generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatab
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   conceptsPerPerson <- querySql(conn,renderedSql)
@@ -1526,7 +1590,7 @@ generateDataDensityReport <- function(conn, dbms,cdmDatabaseSchema, resultsDatab
   
 }
 
-generateMeasurementTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateMeasurementTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating measurement treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -1535,7 +1599,8 @@ generateMeasurementTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   dataMeasurementTreemap <- querySql(conn,queryMeasurementTreemap) 
@@ -1548,7 +1613,7 @@ generateMeasurementTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDat
   
 }
 
-generateMeasurementReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4")
+generateMeasurementReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   writeLines("Generating Measurement reports")
   
@@ -1577,63 +1642,72 @@ generateMeasurementReports <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryMeasurementsByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlMeasurementsByType.sql",cdmVersion),
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstOccurrence <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlAgeAtFirstOccurrence.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   queryRecordsByUnit <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlRecordsByUnit.sql",cdmVersion),
                                                packageName = "Achilles",
                                                dbms = dbms,
                                                cdm_database_schema = cdmDatabaseSchema,
-					       results_database_schema = resultsDatabaseSchema
+                                               results_database_schema = resultsDatabaseSchema,
+                                               vocab_database_schema = vocabDatabaseSchema
   )
   
   queryMeasurementValueDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlMeasurementValueDistribution.sql",cdmVersion),
                                                               packageName = "Achilles",
                                                               dbms = dbms,
                                                               cdm_database_schema = cdmDatabaseSchema,
-							      results_database_schema = resultsDatabaseSchema
+                                                              results_database_schema = resultsDatabaseSchema,
+                                                              vocab_database_schema = vocabDatabaseSchema
   )
   
   queryLowerLimitDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlLowerLimitDistribution.sql",cdmVersion),
                                                         packageName = "Achilles",
                                                         dbms = dbms,
                                                         cdm_database_schema = cdmDatabaseSchema,
-							results_database_schema = resultsDatabaseSchema
+                                                        results_database_schema = resultsDatabaseSchema,
+                                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   queryUpperLimitDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlUpperLimitDistribution.sql",cdmVersion),
                                                         packageName = "Achilles",
                                                         dbms = dbms,
                                                         cdm_database_schema = cdmDatabaseSchema,
-							results_database_schema = resultsDatabaseSchema
+                                                        results_database_schema = resultsDatabaseSchema,
+                                                        vocab_database_schema = vocabDatabaseSchema
   )
   
   queryValuesRelativeToNorm <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/measurement/sqlValuesRelativeToNorm.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -1677,7 +1751,7 @@ generateMeasurementReports <- function(conn, dbms, cdmDatabaseSchema, resultsDat
   
 }
 
-generateObservationTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4") {
+generateObservationTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema) {
   writeLines("Generating observation treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -1686,7 +1760,8 @@ generateObservationTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   dataObservationTreemap <- querySql(conn,queryObservationTreemap) 
@@ -1699,7 +1774,7 @@ generateObservationTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDat
   
 }
 
-generateObservationReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4")
+generateObservationReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema)
 {
   writeLines("Generating Observation reports")
   
@@ -1728,28 +1803,32 @@ generateObservationReports <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryObservationsByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlObservationsByType.sql",cdmVersion),
                                                     packageName = "Achilles",
                                                     dbms = dbms,
                                                     cdm_database_schema = cdmDatabaseSchema,
-						    results_database_schema = resultsDatabaseSchema
+                                                    results_database_schema = resultsDatabaseSchema,
+                                                    vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstOccurrence <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlAgeAtFirstOccurrence.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   if (cdmVersion == "4")
@@ -1759,35 +1838,40 @@ generateObservationReports <- function(conn, dbms, cdmDatabaseSchema, resultsDat
                                                  packageName = "Achilles",
                                                  dbms = dbms,
                                                  cdm_database_schema = cdmDatabaseSchema,
-						 results_database_schema = resultsDatabaseSchema
+                                                 results_database_schema = resultsDatabaseSchema,
+                                                 vocab_database_schema = vocabDatabaseSchema
     )
     
     queryObservationValueDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlObservationValueDistribution.sql",cdmVersion),
                                                                 packageName = "Achilles",
                                                                 dbms = dbms,
                                                                 cdm_database_schema = cdmDatabaseSchema,
-								results_database_schema = resultsDatabaseSchema
+                                                                results_database_schema = resultsDatabaseSchema,
+                                                                vocab_database_schema = vocabDatabaseSchema
     )
     
     queryLowerLimitDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlLowerLimitDistribution.sql",cdmVersion),
                                                           packageName = "Achilles",
                                                           dbms = dbms,
                                                           cdm_database_schema = cdmDatabaseSchema,
-							  results_database_schema = resultsDatabaseSchema
+                                                          results_database_schema = resultsDatabaseSchema,
+                                                          vocab_database_schema = vocabDatabaseSchema
     )
     
     queryUpperLimitDistribution <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlUpperLimitDistribution.sql",cdmVersion),
                                                           packageName = "Achilles",
                                                           dbms = dbms,
                                                           cdm_database_schema = cdmDatabaseSchema,
-							  results_database_schema = resultsDatabaseSchema
+                                                          results_database_schema = resultsDatabaseSchema,
+                                                          vocab_database_schema = vocabDatabaseSchema
     )
     
     queryValuesRelativeToNorm <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/observation/sqlValuesRelativeToNorm.sql",cdmVersion),
                                                         packageName = "Achilles",
                                                         dbms = dbms,
                                                         cdm_database_schema = cdmDatabaseSchema,
-							results_database_schema = resultsDatabaseSchema
+                                                        results_database_schema = resultsDatabaseSchema,
+                                                        vocab_database_schema = vocabDatabaseSchema
     )
   }  
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -1837,7 +1921,7 @@ generateObservationReports <- function(conn, dbms, cdmDatabaseSchema, resultsDat
   
 }
 
-generateVisitTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4"){
+generateVisitTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema){
   writeLines("Generating visit_occurrence treemap")
   progressBar <- txtProgressBar(max=1,style=3)
   progress = 0
@@ -1846,7 +1930,8 @@ generateVisitTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                               packageName = "Achilles",
                                               dbms = dbms,
                                               cdm_database_schema = cdmDatabaseSchema,
-					      results_database_schema = resultsDatabaseSchema
+                                              results_database_schema = resultsDatabaseSchema,
+                                              vocab_database_schema = vocabDatabaseSchema
   )
   
   dataVisitTreemap <- querySql(conn,queryVisitTreemap) 
@@ -1858,7 +1943,7 @@ generateVisitTreemap <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
   close(progressBar)  
 }
 
-generateVisitReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4"){
+generateVisitReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema){
   writeLines("Generating visit reports")
   
   treemapFile <- file.path(outputPath,"visit_treemap.json")
@@ -1886,28 +1971,32 @@ generateVisitReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                                            packageName = "Achilles",
                                                            dbms = dbms,
                                                            cdm_database_schema = cdmDatabaseSchema,
-							   results_database_schema = resultsDatabaseSchema
+                                                           results_database_schema = resultsDatabaseSchema,
+                                                           vocab_database_schema = vocabDatabaseSchema
   )
   
   queryPrevalenceByMonth <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/visit/sqlPrevalenceByMonth.sql",cdmVersion),
                                                    packageName = "Achilles",
                                                    dbms = dbms,
                                                    cdm_database_schema = cdmDatabaseSchema,
-						   results_database_schema = resultsDatabaseSchema
+                                                   results_database_schema = resultsDatabaseSchema,
+                                                   vocab_database_schema = vocabDatabaseSchema
   )
   
   queryVisitDurationByType <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/visit/sqlVisitDurationByType.sql",cdmVersion),
                                                      packageName = "Achilles",
                                                      dbms = dbms,
                                                      cdm_database_schema = cdmDatabaseSchema,
-						     results_database_schema = resultsDatabaseSchema
+                                                     results_database_schema = resultsDatabaseSchema,
+                                                     vocab_database_schema = vocabDatabaseSchema
   )
   
   queryAgeAtFirstOccurrence <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/visit/sqlAgeAtFirstOccurrence.sql",cdmVersion),
                                                       packageName = "Achilles",
                                                       dbms = dbms,
                                                       cdm_database_schema = cdmDatabaseSchema,
-						      results_database_schema = resultsDatabaseSchema
+                                                      results_database_schema = resultsDatabaseSchema,
+                                                      vocab_database_schema = vocabDatabaseSchema
   )
   
   dataPrevalenceByGenderAgeYear <- querySql(conn,queryPrevalenceByGenderAgeYear) 
@@ -1938,7 +2027,7 @@ generateVisitReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
   close(progressBar)  
 }
 
-generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4"){
+generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseSchema, outputPath, cdmVersion = "4", vocabDatabaseSchema = cdmDatabaseSchema){
   writeLines("Generating death reports")
   progressBar <- txtProgressBar(max=4,style=3)
   progress = 0
@@ -1955,7 +2044,8 @@ generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   prevalenceByGenderAgeYearData <- querySql(conn,renderedSql)
@@ -1973,7 +2063,8 @@ generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   prevalenceByMonthData <- querySql(conn,renderedSql)
@@ -1990,7 +2081,8 @@ generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   deathByTypeData <- querySql(conn,renderedSql)
@@ -2007,7 +2099,8 @@ generateDeathReports <- function(conn, dbms, cdmDatabaseSchema, resultsDatabaseS
                                         packageName = "Achilles",
                                         dbms = dbms,
                                         cdm_database_schema = cdmDatabaseSchema,
-					results_database_schema = resultsDatabaseSchema
+                                        results_database_schema = resultsDatabaseSchema,
+                                        vocab_database_schema = vocabDatabaseSchema
   )  
   
   ageAtDeathData <- querySql(conn,renderedSql)

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Getting Started
   ```r
   library(Achilles)
   connectionDetails <- createConnectionDetails(dbms="sql server", server="server.com")
-  achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="cdm4_inst", resultsDatabaseSchema="results", sourceName="My Source Name", cdmVersion = "cdm version")
+  achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="cdm4_inst", resultsDatabaseSchema="results", sourceName="My Source Name", cdmVersion = "cdm version", vocabDatabaseSchema="vocabulary")
   ```
-  "cdm4_inst" cdmDatabaseSchema parmater and "results" resultsDatabaseSchema parameter are the names of the schemas holding the CDM data and target results respectively. See the [DatabaseConnector](https://github.com/OHDSI/DatabaseConnector) package for details on settings the connection details for your database, for example by typing
+  "cdm4_inst" cdmDatabaseSchema parmater, "results" resultsDatabaseSchema parameter, and "vocabulary" vocabDatabaseSchema are the names of the schemas holding the CDM data, targeted for result writing, and holding the Vocabulary data respectively. See the [DatabaseConnector](https://github.com/OHDSI/DatabaseConnector) package for details on settings the connection details for your database, for example by typing
   ```r
   ?createConnectionDetails
   ```
@@ -37,7 +37,7 @@ Getting Started
 
 5. To use [AchillesWeb](https://github.com/OHDSI/AchillesWeb) to explore the Achilles statistics, you must first export the statistics to JSON files:
   ```r
-  exportToJson(connectionDetails, cdmDatabaseSchema = "cdm4_inst", resultsDatabaseSchema = "results", outputPath = "c:/myPath/AchillesExport", cdmVersion = "cdm version")
+  exportToJson(connectionDetails, cdmDatabaseSchema = "cdm4_inst", resultsDatabaseSchema = "results", outputPath = "c:/myPath/AchillesExport", cdmVersion = "cdm version", vocabDatabaseSchema = "vocabulary")
   ```
 
 Getting Started with Docker

--- a/docker-run
+++ b/docker-run
@@ -7,12 +7,12 @@ library(httr)
 # Get passed environment variables.
 env_var_names <- list("ACHILLES_SITE", "ACHILLES_DB_URI",
                       "ACHILLES_CDM_SCHEMA", "ACHILLES_RES_SCHEMA",
-                      "ACHILLES_OUTPUT_BASE")
+                      "ACHILLES_OUTPUT_BASE", "ACHILLES_CDM_VERSION")
 env_vars <- Sys.getenv(env_var_names, unset=NA)
 
 # Replace unset environement variables with defaults.
 default_vars <- list("DefaultSite", "postgresql://localhost/postgres",
-                     "public", "public", "./output")
+                     "public", "public", "./output", "5")
 env_vars[is.na(env_vars)] <- default_vars[is.na(env_vars)]
 
 # Create name to tag results and output path from ACHILLES_SITE and timestamp
@@ -37,11 +37,13 @@ connectionDetails <- createConnectionDetails(
 # Run Achilles report and generate data in the results schema.
 achillesResults <- achilles(
     connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name,
+    cdmVersion=env_vars$ACHILLES_CDM_VERSION
 )
 
 # Export Achilles results to output path in JSON format.
 exportToJson(
     connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path,
+    cdmVersion=env_vars$ACHILLES_CDM_VERSION
 )

--- a/docker-run
+++ b/docker-run
@@ -5,20 +5,20 @@ library(Achilles)
 library(httr)
 
 # Get passed environment variables.
-env_var_names <- list("ACHILLES_SITE", "ACHILLES_DB_URI",
-                      "ACHILLES_CDM_SCHEMA", "ACHILLES_RES_SCHEMA",
-                      "ACHILLES_OUTPUT_BASE", "ACHILLES_CDM_VERSION")
+env_var_names <- list("ACHILLES_SOURCE", "ACHILLES_DB_URI",
+                      "ACHILLES_CDM_SCHEMA", "ACHILLES_VOCAB_SCHEMA",
+                      "ACHILLES_RES_SCHEMA", "ACHILLES_OUTPUT_BASE",
+                      "ACHILLES_CDM_VERSION")
 env_vars <- Sys.getenv(env_var_names, unset=NA)
 
 # Replace unset environement variables with defaults.
-default_vars <- list("DefaultSite", "postgresql://localhost/postgres",
-                     "public", "public", "./output", "5")
+default_vars <- list("N/A", "postgresql://localhost/postgres",
+                     "public", "public", "public", "./output", "5")
 env_vars[is.na(env_vars)] <- default_vars[is.na(env_vars)]
 
-# Create name to tag results and output path from ACHILLES_SITE and timestamp
-current_datetime <- strftime(Sys.time(), format="%Y-%m-%dT%H:%M:%S")
-src_name <- paste(env_vars$ACHILLES_SITE, current_datetime, sep=" ")
-output_path <- paste(env_vars$ACHILLES_OUTPUT_BASE, env_vars$ACHILLES_SITE,
+# Create name to tag results and output path from ACHILLES_SOURCE and timestamp
+current_datetime <- strftime(Sys.time(), format="%Y-%m-%dT%H.%M.%S")
+output_path <- paste(env_vars$ACHILLES_OUTPUT_BASE, env_vars$ACHILLES_SOURCE,
                      current_datetime, sep="/")
 dir.create(output_path, showWarnings=FALSE, recursive=TRUE, mode="0755")
 
@@ -37,13 +37,16 @@ connectionDetails <- createConnectionDetails(
 # Run Achilles report and generate data in the results schema.
 achillesResults <- achilles(
     connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, sourceName=src_name,
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA,
+    vocabDatabaseSchema=env_vars$ACHILLES_VOCAB_SCHEMA,
+    sourceName=env_vars$ACHILLES_SOURCE,
     cdmVersion=env_vars$ACHILLES_CDM_VERSION
 )
 
 # Export Achilles results to output path in JSON format.
 exportToJson(
     connectionDetails, cdmDatabaseSchema=env_vars$ACHILLES_CDM_SCHEMA,
-    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA, outputPath=output_path,
-    cdmVersion=env_vars$ACHILLES_CDM_VERSION
+    resultsDatabaseSchema=env_vars$ACHILLES_RES_SCHEMA,
+    vocabDatabaseSchema=env_vars$ACHILLES_VOCAB_SCHEMA,
+    outputPath=output_path, cdmVersion=env_vars$ACHILLES_CDM_VERSION
 )

--- a/env_vars.sample
+++ b/env_vars.sample
@@ -2,3 +2,5 @@ ACHILLES_SITE=<site_name>
 ACHILLES_DB_URI=<db_uri>
 ACHILLES_CDM_SCHEMA=<cdm_schema>
 ACHILLES_RES_SCHEMA=<results_schema>
+ACHILLES_CDM_VERSION=<cdm_version>
+ACHILLES_OUTPUT_BASE=<mounted_output_dir>

--- a/env_vars.sample
+++ b/env_vars.sample
@@ -1,6 +1,7 @@
-ACHILLES_SITE=<site_name>
+ACHILLES_SOURCE=<source_name>
 ACHILLES_DB_URI=<db_uri>
 ACHILLES_CDM_SCHEMA=<cdm_schema>
+ACHILLES_VOCAB_SCHEMA=<vocab_schema>
 ACHILLES_RES_SCHEMA=<results_schema>
 ACHILLES_CDM_VERSION=<cdm_version>
 ACHILLES_OUTPUT_BASE=<mounted_output_dir>

--- a/inst/sql/sql_server/AchillesHeel_v4.sql
+++ b/inst/sql/sql_server/AchillesHeel_v4.sql
@@ -76,7 +76,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (2)
 	AND or1.stratum_1 IS NOT NULL
@@ -99,7 +99,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (4)
 	AND or1.stratum_1 IS NOT NULL
@@ -122,7 +122,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (5)
 	AND or1.stratum_1 IS NOT NULL
@@ -145,7 +145,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (202)
 	AND or1.stratum_1 IS NOT NULL
@@ -168,7 +168,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (301)
 	AND or1.stratum_1 IS NOT NULL
@@ -191,7 +191,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		400,
@@ -217,7 +217,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		700,
@@ -243,7 +243,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (600)
 	AND or1.stratum_1 IS NOT NULL
@@ -266,7 +266,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (800)
 	AND or1.stratum_1 IS NOT NULL
@@ -289,7 +289,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (1609)
 	AND or1.stratum_1 IS NOT NULL
@@ -455,7 +455,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-LEFT JOIN @cdm_database_schema.concept c1
+LEFT JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		2,
@@ -493,7 +493,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-LEFT JOIN @cdm_database_schema.concept c1
+LEFT JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_2 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		405,
@@ -561,7 +561,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (1610)
 	AND or1.stratum_1 IS NOT NULL

--- a/inst/sql/sql_server/AchillesHeel_v5.sql
+++ b/inst/sql/sql_server/AchillesHeel_v5.sql
@@ -206,7 +206,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-LEFT JOIN @cdm_database_schema.concept c1
+LEFT JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		2,
@@ -244,7 +244,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-LEFT JOIN @cdm_database_schema.concept c1
+LEFT JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_2 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		405,
@@ -307,7 +307,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (2)
 	AND or1.stratum_1 IS NOT NULL
@@ -330,7 +330,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (4)
 	AND or1.stratum_1 IS NOT NULL
@@ -353,7 +353,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (5)
 	AND or1.stratum_1 IS NOT NULL
@@ -376,7 +376,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (202)
 	AND or1.stratum_1 IS NOT NULL
@@ -399,7 +399,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (301)
 	AND or1.stratum_1 IS NOT NULL
@@ -422,7 +422,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		400,
@@ -448,7 +448,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (
 		700,
@@ -474,7 +474,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (600)
 	AND or1.stratum_1 IS NOT NULL
@@ -506,7 +506,7 @@ SELECT or1.analysis_id,
 FROM @results_database_schema.ACHILLES_results or1
 INNER JOIN @results_database_schema.ACHILLES_analysis oa1
 	ON or1.analysis_id = oa1.analysis_id
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON or1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 WHERE or1.analysis_id IN (1610)
 	AND or1.stratum_1 IS NOT NULL

--- a/inst/sql/sql_server/export_v4/condition/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export_v4/condition/sqlAgeAtFirstDiagnosis.sql
@@ -9,9 +9,9 @@
   	ard1.max_value as max_value
   from @results_database_schema.ACHILLES_results_dist ard1
   	inner join
-  	@cdm_database_schema.concept c1
+  	@vocab_database_schema.concept c1
   	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
   	inner join
-  	@cdm_database_schema.concept c2
+  	@vocab_database_schema.concept c2
   	on CAST(ard1.stratum_2 AS INT) = c2.concept_id
   where ard1.analysis_id = 406

--- a/inst/sql/sql_server/export_v4/condition/sqlConditionTreemap.sql
+++ b/inst/sql/sql_server/export_v4/condition/sqlConditionTreemap.sql
@@ -18,19 +18,19 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from	
 		(
 		select concept_id, concept_name
-		from @cdm_database_schema.concept
+		from @vocab_database_schema.concept
 		where vocabulary_id = 1
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'Preferred Term'
@@ -41,14 +41,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as pt_concept_id, c1.concept_name as pt_concept_name, max(c2.concept_id) as hlt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'Preferred Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'High Level Term'
@@ -59,14 +59,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlt_concept_id, c1.concept_name as hlt_concept_name, max(c2.concept_id) as hlgt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'High Level Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'High Level Group Term'
@@ -77,14 +77,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlgt_concept_id, c1.concept_name as hlgt_concept_name, max(c2.concept_id) as soc_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'High Level Group Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'System Organ Class'
@@ -92,7 +92,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			) hlgt_to_soc
 		on hlt_to_hlgt.hlgt_concept_id = hlgt_to_soc.hlgt_concept_id
 
-		left join @cdm_database_schema.concept soc
+		left join @vocab_database_schema.concept soc
 		 on hlgt_to_soc.soc_concept_id = soc.concept_id
 
 

--- a/inst/sql/sql_server/export_v4/condition/sqlConditionsByType.sql
+++ b/inst/sql/sql_server/export_v4/condition/sqlConditionsByType.sql
@@ -5,7 +5,7 @@ select c1.concept_id as condition_concept_id,
        sum(ar1.count_value) as count_value
 from @results_database_schema.ACHILLES_results ar1
        inner join
-       @cdm_database_schema.concept c1
+       @vocab_database_schema.concept c1
        on CAST(ar1.stratum_1 AS INT) = c1.concept_id
        inner join
        (
@@ -26,7 +26,7 @@ from @results_database_schema.ACHILLES_results ar1
                     case when (concept_name like 'Inpatient%' or concept_name like 'Outpatient%' ) and (concept_name like '%primary%' or concept_name like '%1st position%') then 'Primary diagnosis'
                     when (concept_name like 'Inpatient%' or concept_name like 'Outpatient%' ) and (concept_name not like '%primary%' and concept_name not like '%1st position%') then 'Secondary diagnosis'
                     else '' end as concept_group_name
-       from @cdm_database_schema.concept
+       from @vocab_database_schema.concept
        where vocabulary_id = 37
        
        ) c2

--- a/inst/sql/sql_server/export_v4/condition/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/condition/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/condition/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/condition/sqlPrevalenceByMonth.sql
@@ -8,6 +8,6 @@
   	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
   	on num.stratum_2 = denom.stratum_1  --calendar year
   	inner join
-  	@cdm_database_schema.concept c1
+  	@vocab_database_schema.concept c1
   	on CAST(num.stratum_1 AS INT) = c1.concept_id
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/conditionera/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export_v4/conditionera/sqlAgeAtFirstDiagnosis.sql
@@ -8,9 +8,9 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1
+	inner join @vocab_database_schema.concept c1
 	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
-	inner join @cdm_database_schema.concept c2
+	inner join @vocab_database_schema.concept c2
 	on CAST(ard1.stratum_2 AS INT) = c2.concept_id
 where ard1.analysis_id = 1006
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/conditionera/sqlConditionEraTreemap.sql
+++ b/inst/sql/sql_server/export_v4/conditionera/sqlConditionEraTreemap.sql
@@ -18,19 +18,19 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from	
 		(
 		select concept_id, concept_name
-		from @cdm_database_schema.concept
+		from @vocab_database_schema.concept
 		where vocabulary_id = 1
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'Preferred Term'
@@ -41,14 +41,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as pt_concept_id, c1.concept_name as pt_concept_name, max(c2.concept_id) as hlt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'Preferred Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'High Level Term'
@@ -59,14 +59,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlt_concept_id, c1.concept_name as hlt_concept_name, max(c2.concept_id) as hlgt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'High Level Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'High Level Group Term'
@@ -77,21 +77,21 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlgt_concept_id, c1.concept_name as hlgt_concept_name, max(c2.concept_id) as soc_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 15
 			and c1.concept_class = 'High Level Group Term'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 15
 			and c2.concept_class = 'System Organ Class'
 			group by c1.concept_id, c1.concept_name
 			) hlgt_to_soc
 		on hlt_to_hlgt.hlgt_concept_id = hlgt_to_soc.hlgt_concept_id
-		left join @cdm_database_schema.concept soc
+		left join @vocab_database_schema.concept soc
 		 on hlgt_to_soc.soc_concept_id = soc.concept_id
 	) concept_hierarchy
 	on CAST(ar1.stratum_1 AS INT) = concept_hierarchy.concept_id

--- a/inst/sql/sql_server/export_v4/conditionera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export_v4/conditionera/sqlLengthOfEra.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on CAST(ard1.stratum_1 as INT) = c1.concept_id
+	inner join @vocab_database_schema.concept c1 on CAST(ard1.stratum_1 as INT) = c1.concept_id
 where ard1.analysis_id = 1007 and ard1.count_value > 0
 
 

--- a/inst/sql/sql_server/export_v4/conditionera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/conditionera/sqlPrevalenceByGenderAgeYear.sql
@@ -26,9 +26,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/conditionera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/conditionera/sqlPrevalenceByMonth.sql
@@ -7,4 +7,4 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join
-	@cdm_database_schema.concept c1 on CAST(num.stratum_1 as INT) = c1.concept_id
+	@vocab_database_schema.concept c1 on CAST(num.stratum_1 as INT) = c1.concept_id

--- a/inst/sql/sql_server/export_v4/death/sqlAgeAtDeath.sql
+++ b/inst/sql/sql_server/export_v4/death/sqlAgeAtDeath.sql
@@ -8,5 +8,5 @@ select c2.concept_name as category,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c2 on CAST(ard1.stratum_1 as INT) = c2.concept_id
+	@vocab_database_schema.concept c2 on CAST(ard1.stratum_1 as INT) = c2.concept_id
 where ard1.analysis_id = 506

--- a/inst/sql/sql_server/export_v4/death/sqlDeathByType.sql
+++ b/inst/sql/sql_server/export_v4/death/sqlDeathByType.sql
@@ -2,5 +2,5 @@ select c2.concept_id as concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join  @cdm_database_schema.concept c2 on CAST(ar1.stratum_1 AS INT) = c2.concept_id
+	inner join  @vocab_database_schema.concept c2 on CAST(ar1.stratum_1 AS INT) = c2.concept_id
 where ar1.analysis_id = 505

--- a/inst/sql/sql_server/export_v4/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/death/sqlPrevalenceByGenderAgeYear.sql
@@ -8,6 +8,6 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 116) denom on num.stratum_1 = denom.stratum_1  --calendar year
 		and num.stratum_2 = denom.stratum_2 --gender
 		and num.stratum_3 = denom.stratum_3 --age decile
-	inner join @cdm_database_schema.concept c2 on CAST(num.stratum_2 as INT) = c2.concept_id
+	inner join @vocab_database_schema.concept c2 on CAST(num.stratum_2 as INT) = c2.concept_id
 where c2.concept_id in (8507, 8532)
 ORDER BY CAST(num.stratum_1 as INT)

--- a/inst/sql/sql_server/export_v4/drug/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlAgeAtFirstExposure.sql
@@ -9,10 +9,10 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ard1.stratum_2 = CAST(c2.concept_id AS VARCHAR)
 where ard1.analysis_id = 706
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drug/sqlDaysSupplyDistribution.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlDaysSupplyDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 715
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drug/sqlDrugTreemap.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlDrugTreemap.sql
@@ -25,11 +25,11 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			c1.concept_name, 
 			c2.concept_id as rxnorm_ingredient_concept_id, 
 			c2.concept_name as RxNorm_ingredient_concept_name
-		from @cdm_database_schema.concept c1
-			inner join @cdm_database_schema.concept_ancestor ca1
+		from @vocab_database_schema.concept c1
+			inner join @vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 8
-			inner join @cdm_database_schema.concept c2
+			inner join @vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 8
 			and c2.concept_class = 'Ingredient'
@@ -37,14 +37,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as rxnorm_ingredient_concept_id, max(c2.concept_id) as atc5_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 8
 			and c1.concept_class = 'Ingredient'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 5
@@ -55,14 +55,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc5_concept_id, c1.concept_name as atc5_concept_name, max(c2.concept_id) as atc3_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 21
 			and len(c1.concept_code) = 5
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 3
@@ -73,14 +73,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc3_concept_id, c1.concept_name as atc3_concept_name, max(c2.concept_id) as atc1_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 21
 			and len(c1.concept_code) = 3
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 1
@@ -88,7 +88,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			) atc3_to_atc1
 		on atc5_to_atc3.atc3_concept_id = atc3_to_atc1.atc3_concept_id
 
-		left join @cdm_database_schema.concept atc1
+		left join @vocab_database_schema.concept atc1
 		 on atc3_to_atc1.atc1_concept_id = atc1.concept_id
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.concept_id AS VARCHAR)

--- a/inst/sql/sql_server/export_v4/drug/sqlDrugsByType.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlDrugsByType.sql
@@ -4,9 +4,9 @@ select c1.concept_id as drug_concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ar1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ar1.stratum_2  = CAST(c2.concept_id AS VARCHAR)
 where ar1.analysis_id = 705

--- a/inst/sql/sql_server/export_v4/drug/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/drug/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlPrevalenceByMonth.sql
@@ -8,6 +8,6 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(num.stratum_1 AS INT) = c1.concept_id
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/drug/sqlQuantityDistribution.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlQuantityDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 717
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drug/sqlRefillsDistribution.sql
+++ b/inst/sql/sql_server/export_v4/drug/sqlRefillsDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 716
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drugera/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlAgeAtFirstExposure.sql
@@ -9,10 +9,10 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ard1.stratum_2 = cast(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 906
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drugera/sqlDrugEraTreemap.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlDrugEraTreemap.sql
@@ -21,21 +21,21 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		(
 		select c1.concept_id as rxnorm_ingredient_concept_id, 
 			c1.concept_name as RxNorm_ingredient_concept_name
-		from @cdm_database_schema.concept c1
+		from @vocab_database_schema.concept c1
 		where c1.vocabulary_id = 8
 			and c1.concept_class = 'Ingredient'
 		) rxnorm
 		left join
 			(select c1.concept_id as rxnorm_ingredient_concept_id, max(c2.concept_id) as atc5_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 8
 			and c1.concept_class = 'Ingredient'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 5
@@ -45,14 +45,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc5_concept_id, c1.concept_name as atc5_concept_name, max(c2.concept_id) as atc3_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 21
 			and len(c1.concept_code) = 5
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 3
@@ -62,21 +62,21 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc3_concept_id, c1.concept_name as atc3_concept_name, max(c2.concept_id) as atc1_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 21
 			and len(c1.concept_code) = 3
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 21
 			and len(c2.concept_code) = 1
 			group by c1.concept_id, c1.concept_name
 			) atc3_to_atc1
 		on atc5_to_atc3.atc3_concept_id = atc3_to_atc1.atc3_concept_id
-		left join @cdm_database_schema.concept atc1
+		left join @vocab_database_schema.concept atc1
 		 on atc3_to_atc1.atc1_concept_id = atc1.concept_id
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.rxnorm_ingredient_concept_id AS VARCHAR)

--- a/inst/sql/sql_server/export_v4/drugera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlLengthOfEra.sql
@@ -9,7 +9,7 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 907
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/drugera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlPrevalenceByGenderAgeYear.sql
@@ -26,9 +26,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/drugera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/drugera/sqlPrevalenceByMonth.sql
@@ -7,6 +7,6 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/observation/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlAgeAtFirstOccurrence.sql
@@ -8,6 +8,6 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 806

--- a/inst/sql/sql_server/export_v4/observation/sqlLowerLimitDistribution.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlLowerLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = cast(c2.concept_id AS VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = cast(c2.concept_id AS VARCHAR)
 where ard1.analysis_id = 816
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/observation/sqlObservationTreemap.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlObservationTreemap.sql
@@ -16,14 +16,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from
 		(
 		select concept_id, concept_name
-		from @cdm_database_schema.concept
+		from @vocab_database_schema.concept
 		where vocabulary_id = 6
-		) obs left join @cdm_database_schema.concept_ancestor ca1 on obs.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
-		left join @cdm_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
-		left join @cdm_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
+		) obs left join @vocab_database_schema.concept_ancestor ca1 on obs.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
+		left join @vocab_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
+		left join @vocab_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
 		group by obs.concept_id, obs.concept_name
 	) concept_hierarchy on ar1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR),
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom

--- a/inst/sql/sql_server/export_v4/observation/sqlObservationValueDistribution.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlObservationValueDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 815
 and ard1.count_value > 0
 

--- a/inst/sql/sql_server/export_v4/observation/sqlObservationsByType.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlObservationsByType.sql
@@ -4,6 +4,6 @@ select c1.concept_id as OBSERVATION_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 805

--- a/inst/sql/sql_server/export_v4/observation/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/observation/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlPrevalenceByMonth.sql
@@ -6,5 +6,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 802) num
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/observation/sqlRecordsByUnit.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlRecordsByUnit.sql
@@ -4,6 +4,6 @@ select c1.concept_id as observation_concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 807

--- a/inst/sql/sql_server/export_v4/observation/sqlUpperLimitDistribution.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlUpperLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 817
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v4/observation/sqlValuesRelativeToNorm.sql
+++ b/inst/sql/sql_server/export_v4/observation/sqlValuesRelativeToNorm.sql
@@ -4,6 +4,6 @@ select c1.concept_id as observation_concept_id,
 	c2.concept_name + ': ' + ar1.stratum_3 as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 818

--- a/inst/sql/sql_server/export_v4/observationperiod/agebygender.sql
+++ b/inst/sql/sql_server/export_v4/observationperiod/agebygender.sql
@@ -7,5 +7,5 @@ select c1.concept_name as Category,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-inner join @cdm_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
+inner join @vocab_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 104

--- a/inst/sql/sql_server/export_v4/observationperiod/observationlengthbygender.sql
+++ b/inst/sql/sql_server/export_v4/observationperiod/observationlengthbygender.sql
@@ -7,5 +7,5 @@ select c1.concept_name as category,
   ard1.p90_value as p90_value,
   ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-inner join @cdm_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
+inner join @vocab_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 106

--- a/inst/sql/sql_server/export_v4/person/ethnicity.sql
+++ b/inst/sql/sql_server/export_v4/person/ethnicity.sql
@@ -3,6 +3,6 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ar1.stratum_1 AS INT) = c1.concept_id
 where ar1.analysis_id = 5

--- a/inst/sql/sql_server/export_v4/person/gender.sql
+++ b/inst/sql/sql_server/export_v4/person/gender.sql
@@ -3,7 +3,7 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ar1.stratum_1 AS INT) = c1.concept_id
 where ar1.analysis_id = 2
 and c1.concept_id in (8507, 8532)

--- a/inst/sql/sql_server/export_v4/person/race.sql
+++ b/inst/sql/sql_server/export_v4/person/race.sql
@@ -3,6 +3,6 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ar1.stratum_1 AS INT) = c1.concept_id
 where ar1.analysis_id = 4

--- a/inst/sql/sql_server/export_v4/procedure/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v4/procedure/sqlAgeAtFirstOccurrence.sql
@@ -9,9 +9,9 @@
   	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on CAST(ard1.stratum_2 AS INT) = c2.concept_id
 where ard1.analysis_id = 606

--- a/inst/sql/sql_server/export_v4/procedure/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/procedure/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/procedure/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/procedure/sqlPrevalenceByMonth.sql
@@ -7,5 +7,5 @@ from
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) 
 	denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS INT) = c1.concept_id
+	inner join @vocab_database_schema.concept c1 on CAST(num.stratum_1 AS INT) = c1.concept_id
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/procedure/sqlProcedureTreemap.sql
+++ b/inst/sql/sql_server/export_v4/procedure/sqlProcedureTreemap.sql
@@ -21,8 +21,8 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		(
 		select c1.concept_id, 
 			v1.vocabulary_name + ' ' + c1.concept_code + ': ' + c1.concept_name as proc_concept_name
-		from @cdm_database_schema.concept c1
-			inner join @cdm_database_schema.vocabulary v1
+		from @vocab_database_schema.concept c1
+			inner join @vocab_database_schema.vocabulary v1
 			on c1.vocabulary_id = v1.vocabulary_id
 		where (
 			c1.vocabulary_id in (3,4,5)
@@ -32,18 +32,18 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 
 	left join
 		(select ca0.DESCENDANT_CONCEPT_ID, max(ca0.ancestor_concept_id) as ancestor_concept_id
-		from @cdm_database_schema.concept_ancestor ca0
+		from @vocab_database_schema.concept_ancestor ca0
 		inner join
 		(select distinct c2.concept_id as os3_concept_id
-		 from @cdm_database_schema.concept_ancestor ca1
+		 from @vocab_database_schema.concept_ancestor ca1
 			inner join
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 			inner join
-			@cdm_database_schema.concept_ancestor ca2
+			@vocab_database_schema.concept_ancestor ca2
 			on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 			inner join
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 		 where ca1.ancestor_concept_id = 4040390
 		 and ca1.Min_LEVELS_OF_SEPARATION = 2
@@ -64,9 +64,9 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		proc_by_os3.os3_concept_id
 	from
 	 (select DESCENDANT_CONCEPT_ID as os1_concept_id, concept_name as os1_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 	 where ancestor_concept_id = 4040390
 	 and Min_LEVELS_OF_SEPARATION = 1
@@ -74,15 +74,15 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 
 	 inner join
 	 (select max(c1.CONCEPT_ID) as os1_concept_id, c2.concept_id as os2_concept_id, c2.concept_name as os2_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 		inner join
-		@cdm_database_schema.concept_ancestor ca2
+		@vocab_database_schema.concept_ancestor ca2
 		on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 		inner join
-		@cdm_database_schema.concept c2
+		@vocab_database_schema.concept c2
 		on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 	 where ca1.ancestor_concept_id = 4040390
 	 and ca1.Min_LEVELS_OF_SEPARATION = 1
@@ -93,15 +93,15 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 
 	 inner join
 	 (select max(c1.CONCEPT_ID) as os2_concept_id, c2.concept_id as os3_concept_id, c2.concept_name as os3_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 		inner join
-		@cdm_database_schema.concept_ancestor ca2
+		@vocab_database_schema.concept_ancestor ca2
 		on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 		inner join
-		@cdm_database_schema.concept c2
+		@vocab_database_schema.concept c2
 		on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 	 where ca1.ancestor_concept_id = 4040390
 	 and ca1.Min_LEVELS_OF_SEPARATION = 2

--- a/inst/sql/sql_server/export_v4/procedure/sqlProceduresByType.sql
+++ b/inst/sql/sql_server/export_v4/procedure/sqlProceduresByType.sql
@@ -4,6 +4,6 @@ select c1.concept_id as procedure_concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on CAST(ar1.stratum_1 AS INT) = c1.concept_id
-	inner join @cdm_database_schema.concept c2 on CAST(ar1.stratum_2 AS INT) = c2.concept_id
+	inner join @vocab_database_schema.concept c1 on CAST(ar1.stratum_1 AS INT) = c1.concept_id
+	inner join @vocab_database_schema.concept c2 on CAST(ar1.stratum_2 AS INT) = c2.concept_id
 where ar1.analysis_id = 605

--- a/inst/sql/sql_server/export_v4/visit/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v4/visit/sqlAgeAtFirstOccurrence.sql
@@ -8,6 +8,6 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
-	inner join @cdm_database_schema.concept c2 on CAST(ard1.stratum_2 AS INT) = c2.concept_id
+	inner join @vocab_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
+	inner join @vocab_database_schema.concept c2 on CAST(ard1.stratum_2 AS INT) = c2.concept_id
 where ard1.analysis_id = 206

--- a/inst/sql/sql_server/export_v4/visit/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v4/visit/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = c1.concept_id
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = c2.concept_id
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v4/visit/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v4/visit/sqlPrevalenceByMonth.sql
@@ -6,5 +6,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 202) num
 	inner join
 		(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on CAST(num.stratum_1 AS INT) = c1.concept_id
+	inner join @vocab_database_schema.concept c1 on CAST(num.stratum_1 AS INT) = c1.concept_id
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v4/visit/sqlVisitDurationByType.sql
+++ b/inst/sql/sql_server/export_v4/visit/sqlVisitDurationByType.sql
@@ -9,5 +9,5 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
+	@vocab_database_schema.concept c1 on CAST(ard1.stratum_1 AS INT) = c1.concept_id
 where ard1.analysis_id = 211

--- a/inst/sql/sql_server/export_v4/visit/sqlVisitTreemap.sql
+++ b/inst/sql/sql_server/export_v4/visit/sqlVisitTreemap.sql
@@ -6,6 +6,6 @@ select 	c1.concept_id,
 from (select * from @results_database_schema.ACHILLES_results where analysis_id = 200) ar1
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 201) ar2 on ar1.stratum_1 = ar2.stratum_1
-	inner join @cdm_database_schema.concept c1 on CAST(ar1.stratum_1 AS INT) = c1.concept_id,
+	inner join @vocab_database_schema.concept c1 on CAST(ar1.stratum_1 AS INT) = c1.concept_id,
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom
 order by ar1.count_value desc

--- a/inst/sql/sql_server/export_v5/condition/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlAgeAtFirstDiagnosis.sql
@@ -9,9 +9,9 @@
   	ard1.max_value as max_value
   from @results_database_schema.ACHILLES_results_dist ard1
   	inner join
-  	@cdm_database_schema.concept c1
+  	@vocab_database_schema.concept c1
   	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
   	inner join
-  	@cdm_database_schema.concept c2
+  	@vocab_database_schema.concept c2
   	on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
   where ard1.analysis_id = 406

--- a/inst/sql/sql_server/export_v5/condition/sqlConditionTreemap.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlConditionTreemap.sql
@@ -17,20 +17,20 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from	
 		(
 			select concept_id, concept_name
-			from @cdm_database_schema.concept
+			from @vocab_database_schema.concept
 			where domain_id = 'Condition'
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.domain_id = 'Condition'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id
@@ -40,14 +40,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as pt_concept_id, c1.concept_name as pt_concept_name, max(c2.concept_id) as hlt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-		  @cdm_database_schema.concept c2
+		  @vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
@@ -57,14 +57,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlt_concept_id, c1.concept_name as hlt_concept_name, max(c2.concept_id) as hlgt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
@@ -74,21 +74,21 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlgt_concept_id, c1.concept_name as hlgt_concept_name, max(c2.concept_id) as soc_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
 			) hlgt_to_soc
 		on hlt_to_hlgt.hlgt_concept_id = hlgt_to_soc.hlgt_concept_id
 
-		left join @cdm_database_schema.concept soc
+		left join @vocab_database_schema.concept soc
 		 on hlgt_to_soc.soc_concept_id = soc.concept_id
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/condition/sqlConditionsByType.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlConditionsByType.sql
@@ -5,7 +5,7 @@ select c1.concept_id as condition_concept_id,
        sum(ar1.count_value) as count_value
 from @results_database_schema.ACHILLES_results ar1
        inner join
-       @cdm_database_schema.concept c1
+       @vocab_database_schema.concept c1
        on ar1.stratum_1 = cast(c1.concept_id as VARCHAR)
        inner join
        (
@@ -26,7 +26,7 @@ from @results_database_schema.ACHILLES_results ar1
                     case when (concept_name like 'Inpatient%' or concept_name like 'Outpatient%' ) and (concept_name like '%primary%' or concept_name like '%1st position%') then 'Primary diagnosis'
                     when (concept_name like 'Inpatient%' or concept_name like 'Outpatient%' ) and (concept_name not like '%primary%' and concept_name not like '%1st position%') then 'Secondary diagnosis'
                     else '' end as concept_group_name
-       from @cdm_database_schema.concept
+       from @vocab_database_schema.concept
        where lower(domain_id) = 'condition type' 
        
        ) c2

--- a/inst/sql/sql_server/export_v5/condition/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v5/condition/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/condition/sqlPrevalenceByMonth.sql
@@ -8,6 +8,6 @@
   	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
   	on num.stratum_2 = denom.stratum_1  --calendar year
   	inner join
-  	@cdm_database_schema.concept c1
+  	@vocab_database_schema.concept c1
   	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v5/conditionera/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlAgeAtFirstDiagnosis.sql
@@ -8,9 +8,9 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1
+	inner join @vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2
+	inner join @vocab_database_schema.concept c2
 	on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 1006
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/conditionera/sqlConditionEraTreemap.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlConditionEraTreemap.sql
@@ -18,20 +18,20 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from	
 		(
 			select concept_id, concept_name
-			from @cdm_database_schema.concept
+			from @vocab_database_schema.concept
 			where domain_id = 'Condition'
 		) snomed
 		left join
 			(select c1.concept_id as snomed_concept_id, max(c2.concept_id) as pt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.domain_id = 'Condition'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id
@@ -41,14 +41,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as pt_concept_id, c1.concept_name as pt_concept_name, max(c2.concept_id) as hlt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
@@ -58,14 +58,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlt_concept_id, c1.concept_name as hlt_concept_name, max(c2.concept_id) as hlgt_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
@@ -75,21 +75,21 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as hlgt_concept_id, c1.concept_name as hlgt_concept_name, max(c2.concept_id) as soc_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'MedDRA'
 			and ca1.min_levels_of_separation = 1
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'MedDRA'
 			group by c1.concept_id, c1.concept_name
 			) hlgt_to_soc
 		on hlt_to_hlgt.hlgt_concept_id = hlgt_to_soc.hlgt_concept_id
 
-		left join @cdm_database_schema.concept soc
+		left join @vocab_database_schema.concept soc
 		 on hlgt_to_soc.soc_concept_id = soc.concept_id
 
 

--- a/inst/sql/sql_server/export_v5/conditionera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlLengthOfEra.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 1007 and ard1.count_value > 0
 
 

--- a/inst/sql/sql_server/export_v5/conditionera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlPrevalenceByGenderAgeYear.sql
@@ -26,9 +26,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 ORDER BY c1.concept_id,
 	num_stratum_2

--- a/inst/sql/sql_server/export_v5/conditionera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/conditionera/sqlPrevalenceByMonth.sql
@@ -7,4 +7,4 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join
-	@cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	@vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/death/sqlAgeAtDeath.sql
+++ b/inst/sql/sql_server/export_v5/death/sqlAgeAtDeath.sql
@@ -8,5 +8,5 @@ select c2.concept_name as category,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c2 on ard1.stratum_1 = CAST(c2.concept_id as VARCHAR)
+	@vocab_database_schema.concept c2 on ard1.stratum_1 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 506

--- a/inst/sql/sql_server/export_v5/death/sqlDeathByType.sql
+++ b/inst/sql/sql_server/export_v5/death/sqlDeathByType.sql
@@ -2,5 +2,5 @@ select c2.concept_id as concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join  @cdm_database_schema.concept c2 on ar1.stratum_1 = CAST(c2.concept_id as VARCHAR)
+	inner join  @vocab_database_schema.concept c2 on ar1.stratum_1 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 505

--- a/inst/sql/sql_server/export_v5/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/death/sqlPrevalenceByGenderAgeYear.sql
@@ -8,6 +8,6 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 116) denom on num.stratum_1 = denom.stratum_1  --calendar year
 		and num.stratum_2 = denom.stratum_2 --gender
 		and num.stratum_3 = denom.stratum_3 --age decile
-	inner join @cdm_database_schema.concept c2 on num.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on num.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where c2.concept_id in (8507, 8532)
 

--- a/inst/sql/sql_server/export_v5/drug/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlAgeAtFirstExposure.sql
@@ -9,10 +9,10 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ard1.stratum_2 = CAST(c2.concept_id AS VARCHAR)
 where ard1.analysis_id = 706
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drug/sqlDaysSupplyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlDaysSupplyDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 715
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drug/sqlDrugTreemap.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlDrugTreemap.sql
@@ -25,11 +25,11 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			c1.concept_name, 
 			c2.concept_id as rxnorm_ingredient_concept_id, 
 			c2.concept_name as RxNorm_ingredient_concept_name
-		from @cdm_database_schema.concept c1
-			inner join @cdm_database_schema.concept_ancestor ca1
+		from @vocab_database_schema.concept c1
+			inner join @vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.domain_id = 'Drug'
-			inner join @cdm_database_schema.concept c2
+			inner join @vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.domain_id = 'Drug'
 			and c2.concept_class_id = 'Ingredient'
@@ -37,14 +37,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as rxnorm_ingredient_concept_id, max(c2.concept_id) as atc5_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.domain_id = 'Drug'
 			and c1.concept_class_id = 'Ingredient'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
 			and c2.concept_class_id = 'ATC 4th'
@@ -55,14 +55,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc5_concept_id, c1.concept_name as atc5_concept_name, max(c2.concept_id) as atc3_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'ATC'
 			and c1.concept_class_id = 'ATC 4th'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
 			and c2.concept_class_id = 'ATC 2nd'
@@ -73,14 +73,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc3_concept_id, c1.concept_name as atc3_concept_name, max(c2.concept_id) as atc1_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'ATC'
 			and c1.concept_class_id = 'ATC 2nd'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
   		and c2.concept_class_id = 'ATC 1st'
@@ -88,7 +88,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			) atc3_to_atc1
 		on atc5_to_atc3.atc3_concept_id = atc3_to_atc1.atc3_concept_id
 
-		left join @cdm_database_schema.concept atc1
+		left join @vocab_database_schema.concept atc1
 		 on atc3_to_atc1.atc1_concept_id = atc1.concept_id
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.concept_id AS VARCHAR)

--- a/inst/sql/sql_server/export_v5/drug/sqlDrugsByType.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlDrugsByType.sql
@@ -4,9 +4,9 @@ select c1.concept_id as drug_concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ar1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ar1.stratum_2  = CAST(c2.concept_id AS VARCHAR)
 where ar1.analysis_id = 705

--- a/inst/sql/sql_server/export_v5/drug/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlPrevalenceByGenderAgeYear.sql
@@ -27,7 +27,7 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/drug/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlPrevalenceByMonth.sql
@@ -8,5 +8,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/drug/sqlQuantityDistribution.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlQuantityDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 where ard1.analysis_id = 717
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drug/sqlRefillsDistribution.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlRefillsDistribution.sql
@@ -9,7 +9,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 716
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drugera/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlAgeAtFirstExposure.sql
@@ -9,10 +9,10 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ard1.stratum_2 = cast(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 906
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drugera/sqlDrugEraTreemap.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlDrugEraTreemap.sql
@@ -22,7 +22,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		select c2.concept_id as rxnorm_ingredient_concept_id, 
 			c2.concept_name as RxNorm_ingredient_concept_name
 		from 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			where
 			c2.domain_id = 'Drug'
 			and c2.concept_class_id = 'Ingredient'
@@ -30,14 +30,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as rxnorm_ingredient_concept_id, max(c2.concept_id) as atc5_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.domain_id = 'Drug'
 			and c1.concept_class_id = 'Ingredient'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
 			and c2.concept_class_id = 'ATC 4th'
@@ -48,14 +48,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc5_concept_id, c1.concept_name as atc5_concept_name, max(c2.concept_id) as atc3_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'ATC'
 			and c1.concept_class_id = 'ATC 4th'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
 			and c2.concept_class_id = 'ATC 2nd'
@@ -66,14 +66,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		left join
 			(select c1.concept_id as atc3_concept_id, c1.concept_name as atc3_concept_name, max(c2.concept_id) as atc1_concept_id
 			from
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			inner join 
-			@cdm_database_schema.concept_ancestor ca1
+			@vocab_database_schema.concept_ancestor ca1
 			on c1.concept_id = ca1.descendant_concept_id
 			and c1.vocabulary_id = 'ATC'
 			and c1.concept_class_id = 'ATC 2nd'
 			inner join 
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca1.ancestor_concept_id = c2.concept_id
 			and c2.vocabulary_id = 'ATC'
   		and c2.concept_class_id = 'ATC 1st'
@@ -81,7 +81,7 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 			) atc3_to_atc1
 		on atc5_to_atc3.atc3_concept_id = atc3_to_atc1.atc3_concept_id
 
-		left join @cdm_database_schema.concept atc1
+		left join @vocab_database_schema.concept atc1
 		 on atc3_to_atc1.atc1_concept_id = atc1.concept_id
 	) concept_hierarchy
 	on ar1.stratum_1 = CAST(concept_hierarchy.rxnorm_ingredient_concept_id AS VARCHAR)

--- a/inst/sql/sql_server/export_v5/drugera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlLengthOfEra.sql
@@ -9,7 +9,7 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 907
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/drugera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlPrevalenceByGenderAgeYear.sql
@@ -26,8 +26,8 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/drugera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/drugera/sqlPrevalenceByMonth.sql
@@ -7,5 +7,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom
 	on num.stratum_2 = denom.stratum_1  
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on num.stratum_1 = CAST(c1.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/measurement/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlAgeAtFirstOccurrence.sql
@@ -8,6 +8,6 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 1806

--- a/inst/sql/sql_server/export_v5/measurement/sqlLowerLimitDistribution.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlLowerLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = cast(c2.concept_id AS VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = cast(c2.concept_id AS VARCHAR)
 where ard1.analysis_id = 1816
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/measurement/sqlMeasurementTreemap.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlMeasurementTreemap.sql
@@ -16,14 +16,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from
 		(
 		select distinct concept_id, concept_name
-		from @cdm_database_schema.concept c
+		from @vocab_database_schema.concept c
 		join @cdm_database_schema.measurement m on c.concept_id = m.measurement_concept_id
-		) m left join @cdm_database_schema.concept_ancestor ca1 on m.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
-		left join @cdm_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
-		left join @cdm_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
+		) m left join @vocab_database_schema.concept_ancestor ca1 on m.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
+		left join @vocab_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
+		left join @vocab_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
 		group by m.concept_id, m.concept_name
 	) concept_hierarchy on ar1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR),
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom

--- a/inst/sql/sql_server/export_v5/measurement/sqlMeasurementValueDistribution.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlMeasurementValueDistribution.sql
@@ -8,8 +8,8 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 1815
 and ard1.count_value > 0
 

--- a/inst/sql/sql_server/export_v5/measurement/sqlMeasurementsByType.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlMeasurementsByType.sql
@@ -4,6 +4,6 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 1805

--- a/inst/sql/sql_server/export_v5/measurement/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlPrevalenceByGenderAgeYear.sql
@@ -27,8 +27,8 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/measurement/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlPrevalenceByMonth.sql
@@ -6,5 +6,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 1802) num
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/measurement/sqlRecordsByUnit.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlRecordsByUnit.sql
@@ -4,6 +4,6 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 1807

--- a/inst/sql/sql_server/export_v5/measurement/sqlUpperLimitDistribution.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlUpperLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 1817
 and ard1.count_value > 0

--- a/inst/sql/sql_server/export_v5/measurement/sqlValuesRelativeToNorm.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlValuesRelativeToNorm.sql
@@ -4,6 +4,6 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	c2.concept_name + ': ' + ar1.stratum_3 as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 1818

--- a/inst/sql/sql_server/export_v5/observation/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlAgeAtFirstOccurrence.sql
@@ -8,6 +8,6 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 806

--- a/inst/sql/sql_server/export_v5/observation/sqlObservationTreemap.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlObservationTreemap.sql
@@ -16,14 +16,14 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		from
 		(
 			select concept_id, concept_name
-			from @cdm_database_schema.concept
+			from @vocab_database_schema.concept
 			where domain_id = 'Observation'
-		) obs left join @cdm_database_schema.concept_ancestor ca1 on obs.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
-		left join @cdm_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
-		left join @cdm_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
-		left join @cdm_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
+		) obs left join @vocab_database_schema.concept_ancestor ca1 on obs.concept_id = ca1.DESCENDANT_CONCEPT_ID and ca1.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c1 on ca1.ANCESTOR_CONCEPT_ID = c1.concept_id
+		left join @vocab_database_schema.concept_ancestor ca2 on c1.concept_id = ca2.DESCENDANT_CONCEPT_ID and ca2.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c2 on ca2.ANCESTOR_CONCEPT_ID = c2.concept_id
+		left join @vocab_database_schema.concept_ancestor ca3 on c2.concept_id = ca3.DESCENDANT_CONCEPT_ID and ca3.min_levels_of_separation = 1
+		left join @vocab_database_schema.concept c3 on ca3.ANCESTOR_CONCEPT_ID = c3.concept_id
 		group by obs.concept_id, obs.concept_name
 	) concept_hierarchy on ar1.stratum_1 = CAST(concept_hierarchy.concept_id as VARCHAR),
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom

--- a/inst/sql/sql_server/export_v5/observation/sqlObservationsByType.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlObservationsByType.sql
@@ -4,6 +4,6 @@ select c1.concept_id as OBSERVATION_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 805

--- a/inst/sql/sql_server/export_v5/observation/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlPrevalenceByGenderAgeYear.sql
@@ -27,8 +27,8 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/observation/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlPrevalenceByMonth.sql
@@ -6,5 +6,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 802) num
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/observationperiod/agebygender.sql
+++ b/inst/sql/sql_server/export_v5/observationperiod/agebygender.sql
@@ -7,5 +7,5 @@ select c1.concept_name as Category,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 104

--- a/inst/sql/sql_server/export_v5/observationperiod/observationlengthbygender.sql
+++ b/inst/sql/sql_server/export_v5/observationperiod/observationlengthbygender.sql
@@ -7,5 +7,5 @@ select c1.concept_name as category,
   ard1.p90_value as p90_value,
   ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 106

--- a/inst/sql/sql_server/export_v5/person/ethnicity.sql
+++ b/inst/sql/sql_server/export_v5/person/ethnicity.sql
@@ -3,6 +3,6 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ar1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 where ar1.analysis_id = 5

--- a/inst/sql/sql_server/export_v5/person/gender.sql
+++ b/inst/sql/sql_server/export_v5/person/gender.sql
@@ -3,7 +3,7 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
   on ar1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 where ar1.analysis_id = 2
 and c1.concept_id in (8507, 8532)

--- a/inst/sql/sql_server/export_v5/person/race.sql
+++ b/inst/sql/sql_server/export_v5/person/race.sql
@@ -3,6 +3,6 @@ select c1.concept_id as concept_id,
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
   on ar1.stratum_1 = CAST(c1.concept_id AS VARCHAR)
 where ar1.analysis_id = 4

--- a/inst/sql/sql_server/export_v5/procedure/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlAgeAtFirstOccurrence.sql
@@ -9,9 +9,9 @@
   	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1
+	@vocab_database_schema.concept c1
 	on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 	inner join
-	@cdm_database_schema.concept c2
+	@vocab_database_schema.concept c2
 	on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 606

--- a/inst/sql/sql_server/export_v5/procedure/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlPrevalenceByGenderAgeYear.sql
@@ -27,7 +27,7 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)

--- a/inst/sql/sql_server/export_v5/procedure/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlPrevalenceByMonth.sql
@@ -7,5 +7,5 @@ from
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) 
 	denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 ORDER BY CAST(num.stratum_2 as INT)

--- a/inst/sql/sql_server/export_v5/procedure/sqlProcedureTreemap.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlProcedureTreemap.sql
@@ -21,25 +21,25 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		(
 			select c1.concept_id, 
 				v1.vocabulary_name + ' ' + c1.concept_code + ': ' + c1.concept_name as proc_concept_name
-			from @cdm_database_schema.concept c1
-				inner join @cdm_database_schema.vocabulary v1
+			from @vocab_database_schema.concept c1
+				inner join @vocab_database_schema.vocabulary v1
 				on c1.vocabulary_id = v1.vocabulary_id
 			WHERE c1.domain_id = 'Procedure'
 		) procs
 	left join
 		(select ca0.DESCENDANT_CONCEPT_ID, max(ca0.ancestor_concept_id) as ancestor_concept_id
-		from @cdm_database_schema.concept_ancestor ca0
+		from @vocab_database_schema.concept_ancestor ca0
 		inner join
 		(select distinct c2.concept_id as os3_concept_id
-		 from @cdm_database_schema.concept_ancestor ca1
+		 from @vocab_database_schema.concept_ancestor ca1
 			inner join
-			@cdm_database_schema.concept c1
+			@vocab_database_schema.concept c1
 			on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 			inner join
-			@cdm_database_schema.concept_ancestor ca2
+			@vocab_database_schema.concept_ancestor ca2
 			on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 			inner join
-			@cdm_database_schema.concept c2
+			@vocab_database_schema.concept c2
 			on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 		 where ca1.ancestor_concept_id = 4040390
 		 and ca1.Min_LEVELS_OF_SEPARATION = 2
@@ -60,9 +60,9 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 		proc_by_os3.os3_concept_id
 	from
 	 (select DESCENDANT_CONCEPT_ID as os1_concept_id, concept_name as os1_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 	 where ancestor_concept_id = 4040390
 	 and Min_LEVELS_OF_SEPARATION = 1
@@ -70,15 +70,15 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 
 	 inner join
 	 (select max(c1.CONCEPT_ID) as os1_concept_id, c2.concept_id as os2_concept_id, c2.concept_name as os2_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 		inner join
-		@cdm_database_schema.concept_ancestor ca2
+		@vocab_database_schema.concept_ancestor ca2
 		on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 		inner join
-		@cdm_database_schema.concept c2
+		@vocab_database_schema.concept c2
 		on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 	 where ca1.ancestor_concept_id = 4040390
 	 and ca1.Min_LEVELS_OF_SEPARATION = 1
@@ -89,15 +89,15 @@ from (select * from @results_database_schema.ACHILLES_results where analysis_id 
 
 	 inner join
 	 (select max(c1.CONCEPT_ID) as os2_concept_id, c2.concept_id as os3_concept_id, c2.concept_name as os3_concept_name
-	 from @cdm_database_schema.concept_ancestor ca1
+	 from @vocab_database_schema.concept_ancestor ca1
 		inner join
-		@cdm_database_schema.concept c1
+		@vocab_database_schema.concept c1
 		on ca1.DESCENDANT_CONCEPT_ID = c1.concept_id
 		inner join
-		@cdm_database_schema.concept_ancestor ca2
+		@vocab_database_schema.concept_ancestor ca2
 		on c1.concept_id = ca2.ANCESTOR_CONCEPT_ID
 		inner join
-		@cdm_database_schema.concept c2
+		@vocab_database_schema.concept c2
 		on ca2.DESCENDANT_CONCEPT_ID = c2.concept_id
 	 where ca1.ancestor_concept_id = 4040390
 	 and ca1.Min_LEVELS_OF_SEPARATION = 2

--- a/inst/sql/sql_server/export_v5/procedure/sqlProceduresByType.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlProceduresByType.sql
@@ -4,6 +4,6 @@ select c1.concept_id as procedure_concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from @results_database_schema.ACHILLES_results ar1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ar1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ar1.analysis_id = 605

--- a/inst/sql/sql_server/export_v5/visit/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export_v5/visit/sqlAgeAtFirstOccurrence.sql
@@ -8,6 +8,6 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
-	inner join @cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
-	inner join @cdm_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c2 on ard1.stratum_2 = CAST(c2.concept_id as VARCHAR)
 where ard1.analysis_id = 206

--- a/inst/sql/sql_server/export_v5/visit/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export_v5/visit/sqlPrevalenceByGenderAgeYear.sql
@@ -27,9 +27,9 @@ FROM (
 			AND num.stratum_3 = denom.stratum_2
 			AND num.stratum_4 = denom.stratum_3
 	) tmp
-INNER JOIN @cdm_database_schema.concept c1
+INNER JOIN @vocab_database_schema.concept c1
 	ON num_stratum_1 = CAST(c1.concept_id as VARCHAR)
-INNER JOIN @cdm_database_schema.concept c2
+INNER JOIN @vocab_database_schema.concept c2
 	ON num_stratum_3 = CAST(c2.concept_id as VARCHAR)
 
 

--- a/inst/sql/sql_server/export_v5/visit/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export_v5/visit/sqlPrevalenceByMonth.sql
@@ -6,5 +6,5 @@ from
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 202) num
 	inner join
 		(select * from @results_database_schema.ACHILLES_results where analysis_id = 117) denom on num.stratum_2 = denom.stratum_1  --calendar year
-	inner join @cdm_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	inner join @vocab_database_schema.concept c1 on num.stratum_1 = CAST(c1.concept_id as VARCHAR)
 

--- a/inst/sql/sql_server/export_v5/visit/sqlVisitDurationByType.sql
+++ b/inst/sql/sql_server/export_v5/visit/sqlVisitDurationByType.sql
@@ -9,5 +9,5 @@ select c1.concept_id as concept_id,
 	ard1.max_value as max_value
 from @results_database_schema.ACHILLES_results_dist ard1
 	inner join
-	@cdm_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
+	@vocab_database_schema.concept c1 on ard1.stratum_1 = CAST(c1.concept_id as VARCHAR)
 where ard1.analysis_id = 211

--- a/inst/sql/sql_server/export_v5/visit/sqlVisitTreemap.sql
+++ b/inst/sql/sql_server/export_v5/visit/sqlVisitTreemap.sql
@@ -6,6 +6,6 @@ select 	c1.concept_id,
 from (select * from @results_database_schema.ACHILLES_results where analysis_id = 200) ar1
 	inner join
 	(select * from @results_database_schema.ACHILLES_results where analysis_id = 201) ar2 on ar1.stratum_1 = ar2.stratum_1
-	inner join @cdm_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR),
+	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = CAST(c1.concept_id as VARCHAR),
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom
 


### PR DESCRIPTION
Add cdmVersion to env vars and docker-run.

Add backwards compatible vocabDatabaseSchema argument to Achilles
and exportToJson functions (defaults to cdmDatabaseSchema). Alter
SQL to qualify vocab tables with the new argument's value.

Update README, env vars, docker-run for new usage.

**Unable to update roxygen-generated documentation due to local
installation challenges.**

**Not sure how to add tests for this new feature as the tests appear
to be environment-specific, but I am testing locally and will report
back when the run is complete.**