### PR TITLE
docker: Use ubuntu:14.04 and Rutter's PPAs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,42 @@
 # A Docker container to run the OHDSI/Achilles analysis tool
-FROM r-base:3.1.2
+FROM ubuntu:trusty
 
 MAINTAINER Aaron Browne <brownea@email.chop.edu>
 
-# Remove Debain 'jessie' package pinning by r-base.
-RUN echo '' > /etc/apt/apt.conf.d/default
-
-# Install java and clean up.
-RUN apt-get update && \
-    apt-get install -y \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev \
-    openjdk-7-jdk \
+# Install java, R and required packages and clean up.
+RUN echo deb http://ppa.launchpad.net/marutter/rrutter/ubuntu trusty main >> /etc/apt/sources.list && \
+    echo deb http://ppa.launchpad.net/marutter/c2d4u/ubuntu trusty main >> /etc/apt/sources.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C9A7585B49D51698710F3A115E25F516B04C661B && \
+    sed 's#http://.*archive\.ubuntu\.com/ubuntu/#mirror://mirrors.ubuntu.com/mirrors.txt#g' -i /etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      r-base \
+      r-cran-devtools \
+      r-cran-httr \
+      r-cran-rjson \
+      r-cran-stringr \
+      r-cran-rjava \
+      r-cran-dbi \
+      r-cran-ffbase \
+      littler \
+      openjdk-7-jdk \
     && rm -rf /var/lib/apt/lists/* \
     && R CMD javareconf
 
-# Install Achilles requirements
-RUN install2.r --error \
-    devtools \
-    httr \
-    rjson \
-    && installGithub.r \
-    OHDSI/SqlRender \
-    OHDSI/DatabaseConnector \
+# Set default locale
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+	&& locale-gen en_US.utf8 \
+	&& /usr/sbin/update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# Install Achilles requirements that need to be installed from source
+RUN echo 'options(repos=structure(c(CRAN="http://cran.cnr.berkeley.edu/")))' > /root/.Rprofile && \
+    /usr/share/doc/littler/examples/install.r docopt && \
+    /usr/share/doc/littler/examples/installGithub.r \
+      OHDSI/SqlRender \
+      OHDSI/DatabaseConnector \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Configure workspace
@@ -33,11 +46,11 @@ VOLUME /opt/app/output
 
 # Add project files to container
 COPY . /opt/app/
-RUN chmod +x /opt/app/docker-run
 
 # Install Achilles from source
 RUN R CMD INSTALL /opt/app \
-    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
+    && find /opt/app -mindepth 1 -not \( -wholename /opt/app/docker-run -or -wholename /opt/app/output \) -delete
 
 # Define run script as default command
 CMD ["docker-run"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ This is an alternative method for running Achilles that does not require R and J
 
 6. Run Achilles in the background with `docker-compose run -d achilles`.
 
+Alternatively, you can run it with one long command line, like in the following example:
+
+```bash
+docker run \
+  --rm \
+  --net=host \
+  -v "$(pwd)"/output:/opt/app/output \
+  -e ACHILLES_SOURCE=DEFAULT \
+  -e ACHILLES_DB_URI=postgresql://webapi:webapi@localhost:5432/ohdsi \
+  -e ACHILLES_CDM_SCHEMA=cdm5 \
+  -e ACHILLES_VOCAB_SCHEMA=cdm5 \
+  -e ACHILLES_RES_SCHEMA=webapi \
+  -e ACHILLES_CDM_VERSION=5 \
+  <image name>
+```
 
 License
 =======


### PR DESCRIPTION
Also install as many packages from Rutter's PPAs as possible.

Not basing on the r-base image has the disadvantage that it's not possible to pin a specific R version, but that was a bad idea anyway, since quite a few packages were installed from source and CRAN packages tend to drop support for old R versions relatively quickly.

Another big problem with the previous setup was the unholy mix of packages from debian unstable. In fact, the image didn't even build without extra parameters given to apt.

Finally, also leave only output and docker-run under /opt/app after installation.