### PR TITLE
2 new rules 31 and 32  and new derived analyses

### DIFF
--- a/inst/csv/achilles_rule.csv
+++ b/inst/csv/achilles_rule.csv
@@ -28,3 +28,5 @@ rule_id,rule_name,severity,rule_description
 26,implausible quantity for drug,warning,quantity > 600
 27,more than 1 percent of unmapped rows (concept_0 rows),warning,for multiple analyses (4xx;6xx;7xx;8xx;18xx)
 28,percentage of deceased patients,warning,fires if (deceased/all person count * 100)  is less than 1 (anusual if dataset represents a general healthcare data warehouse)
+29,infant diagnosis at senior age,error,mecconium condition
+31,ratio of providers to total patients,notification,ratio

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -1209,7 +1209,11 @@ insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_na
 	values (2001, 'Number of patients with at least 1 Dx and 1 Proc');
 
 insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name)
-	values (2003, 'Number of patients with at least 1 Meas, 1 Dx and 1 Rx');
+	values (2002, 'Number of patients with at least 1 Meas, 1 Dx and 1 Rx');
+	
+insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name)
+	values (2003, 'Number of patients with at least 1 Visit');
+
 
 --end of importing values into analysis lookup table
 
@@ -7339,6 +7343,15 @@ select 2002 as analysis_id,
          ) a
          ;
 --}
+
+
+--{2003 IN (@list_of_analysis_ids)}?{
+-- 2003	Patients with at least one visit
+insert into @results_database_schema.ACHILLES_results (analysis_id, count_value)
+select 2003 as analysis_id,  COUNT_BIG(distinct person_id) as count_value
+from @cdm_database_schema.visit_occurrence;
+--}
+
 
 --final processing of results
 delete from @results_database_schema.ACHILLES_results where count_value <= @smallcellcount;


### PR DESCRIPTION
-new iris measure (patients with no visits) + new related rule 32 for that #100
-new derived analyses/measures #106
-calculations for rules are stored in derived measures and the resulting rule is simple #116
-new rule 31 (patient/provider ratio) (too few providers and too many patients)
-new rule for unmapped data (and derived measures)