### PR TITLE
Run on Impala

### DIFF
--- a/README-impala.md
+++ b/README-impala.md
@@ -1,0 +1,82 @@
+Make sure you have Impala running on a cluster with the Common Data Model data loaded
+as described in [https://github.com/OHDSI/CommonDataModel/tree/master/Impala](https://github.com/OHDSI/CommonDataModel/tree/master/Impala).
+
+Before running Achilles, create a database for the Achilles tables:
+
+```bash
+impala-shell -q 'CREATE DATABASE achilles'
+```
+
+Download the Impala JDBC drivers from the [Cloudera website](http://www.cloudera.com/downloads/connectors/impala/jdbc/2-5-36.html), and install them in a local 
+directory called _~/impala-drivers/Cloudera_ImpalaJDBC4_2.5.36_.
+
+In R, use the following commands to install the Impala development version of Achilles. I used Docker to get all the pre-reqs (and ran `docker run -it --rm -v ~/impala-drivers/:/impala-drivers achilles_achilles bash`).
+
+```r
+install.packages("devtools")
+library(devtools)
+
+install_github("tomwhite/Achilles", ref="impala") 
+```
+
+To run Achilles for a single, simple analysis, try:
+
+```r
+library(Achilles)
+connectionDetails <- createConnectionDetails(dbms="impala", 
+                                             server="bottou01.sjc.cloudera.com",
+                                             schema="omop_cdm",
+                                             pathToDriver = "/impala-drivers/Cloudera_ImpalaJDBC4_2.5.36")
+achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="omop_cdm",
+                            resultsDatabaseSchema="achilles", sourceName="Impala trial", runHeel = FALSE,
+                            cdmVersion = "5", vocabDatabaseSchema="omop_cdm", analysisIds = c(1))
+```
+
+Have a look at the output:
+
+```bash
+impala-shell -q 'select * from achilles.achilles_results'
+```
+
+The following is a more complex analysis:
+
+```r
+achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="omop_cdm",
+                            resultsDatabaseSchema="achilles", sourceName="Impala trial", runHeel = FALSE,
+                            cdmVersion = "5", vocabDatabaseSchema="omop_cdm", analysisIds = c(105))
+```
+
+This is how you can run a set of analyses, by exclusion:
+```r
+allAnalyses=getAnalysisDetails()$analysis_id
+subset1=setdiff(allAnalyses,c(110))
+subset2=Filter(function(X) { X > 0 }, subset1)
+achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="omop_cdm",
+                            resultsDatabaseSchema="achilles", sourceName="Impala trial", runHeel = FALSE, createTable = FALSE,
+                            cdmVersion = "5", vocabDatabaseSchema="omop_cdm", 
+                            analysisIds = subset2)
+```
+
+Note that `createTable` has been set to `FALSE` so that the initial tables are not 
+created, to save time.
+
+Finally, run all of the analyses with:
+
+```r
+achillesResults <- achilles(connectionDetails, cdmDatabaseSchema="omop_cdm",
+                            resultsDatabaseSchema="achilles", sourceName="Impala trial", runHeel = FALSE,
+                            cdmVersion = "5", vocabDatabaseSchema="omop_cdm")
+```
+
+You can uninstall packages with 
+```r
+remove.packages("Achilles")
+remove.packages("DatabaseConnector")
+remove.packages("SqlRender")
+```
+
+If you want to delete all the Achilles results use the following:
+
+```bash
+impala-shell -q 'drop database achilles cascade'
+```

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -2364,9 +2364,9 @@ drop table #tempResults;
 -- 212	Number of persons with at least one visit occurrence by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
 select 212 as analysis_id,   
-	YEAR(visit_start_date) as stratum_1,
-	p1.gender_concept_id as stratum_2,
-	floor((year(visit_start_date) - p1.year_of_birth)/10) as stratum_3, 
+	CAST(YEAR(visit_start_date) AS VARCHAR(255)),
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_2,
+	CAST(floor((year(visit_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_3,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -7523,7 +7523,7 @@ ACHILLES Analyses on DEVICE_EXPOSURE  table
 -- 2100	Number of persons with at least one device exposure , by device_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 2100 as analysis_id, 
-	m.device_CONCEPT_ID as stratum_1,
+	CAST(m.device_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.device_exposure m
@@ -7536,7 +7536,7 @@ group by m.device_CONCEPT_ID
 -- 2101	Number of device exposure  records, by device_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 2101 as analysis_id, 
-m.device_CONCEPT_ID as stratum_1,
+    CAST(m.device_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.device_exposure m
@@ -7550,8 +7550,8 @@ group by m.device_CONCEPT_ID
 -- 2102	Number of persons by device by  start month, by device_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 2102 as analysis_id,   
-	m.device_CONCEPT_ID as stratum_1,
-	YEAR(device_exposure_start_date)*100 + month(device_exposure_start_date) as stratum_2, 
+	CAST(m.device_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(device_exposure_start_date)*100 + month(device_exposure_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 	@cdm_database_schema.device_exposure m
@@ -7567,10 +7567,10 @@ group by m.device_CONCEPT_ID,
 -- 2104	Number of persons with at least one device occurrence, by device_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 2104 as analysis_id,   
-	m.device_CONCEPT_ID as stratum_1,
-	YEAR(device_exposure_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(device_exposure_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(m.device_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(device_exposure_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(device_exposure_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join @cdm_database_schema.device_exposure m on p1.person_id = m.person_id
@@ -7586,8 +7586,8 @@ group by m.device_CONCEPT_ID,
 -- 2105	Number of exposure records by device_concept_id by device_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 2105 as analysis_id, 
-	m.device_CONCEPT_ID as stratum_1,
-	m.device_type_concept_id as stratum_2,
+	CAST(m.device_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(m.device_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from @cdm_database_schema.device_exposure m
 group by m.device_CONCEPT_ID,	
@@ -7613,7 +7613,7 @@ ACHILLES Analyses on NOTE table
 -- 2200	Number of persons with at least one device exposure , by device_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 2200 as analysis_id, 
-	m.note_type_CONCEPT_ID as stratum_1,
+	CAST(m.note_type_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.note m
@@ -7626,7 +7626,7 @@ group by m.note_type_CONCEPT_ID
 -- 2201	Number of device exposure  records, by device_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 2201 as analysis_id, 
-m.note_type_CONCEPT_ID as stratum_1,
+    CAST(m.note_type_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.note m

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -1593,7 +1593,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
   count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM
@@ -1608,8 +1608,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 105 as analysis_id,
@@ -1664,7 +1664,7 @@ overallStats (gender_concept_id, avg_value, stdev_value, min_value, max_value, t
   FROM rawData
   group by gender_concept_id
 ),
-stats (gender_concept_id, count_value, total, rn) as
+statsView (gender_concept_id, count_value, total, rn) as
 (
   select gender_concept_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -1673,8 +1673,8 @@ stats (gender_concept_id, count_value, total, rn) as
 priorStats (gender_concept_id,count_value, total, accumulated) as
 (
   select s.gender_concept_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.gender_concept_id = p.gender_concept_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.gender_concept_id = p.gender_concept_id and p.rn <= s.rn
   group by s.gender_concept_id, s.count_value, s.total, s.rn
 )
 select 106 as analysis_id,
@@ -1734,7 +1734,7 @@ overallStats (age_decile, avg_value, stdev_value, min_value, max_value, total) a
   from rawData
   group by age_decile
 ),
-stats (age_decile, count_value, total, rn) as
+statsView (age_decile, count_value, total, rn) as
 (
   select age_decile,
     count_value, 
@@ -1746,8 +1746,8 @@ stats (age_decile, count_value, total, rn) as
 priorStats (age_decile,count_value, total, accumulated) as
 (
   select s.age_decile, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.age_decile = p.age_decile and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.age_decile = p.age_decile and p.rn <= s.rn
   group by s.age_decile, s.count_value, s.total, s.rn
 )
 select 107 as analysis_id,
@@ -2105,7 +2105,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -2116,8 +2116,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 203 as analysis_id,
@@ -2201,7 +2201,7 @@ overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, max_v
   FROM rawData
 	group by stratum1_id, stratum2_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select stratum1_id, stratum2_id, count_value, count_big(*) as total, row_number() over (partition by stratum1_id, stratum2_id order by count_value) as rn
   FROM rawData
@@ -2210,8 +2210,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 206 as analysis_id,
@@ -2317,7 +2317,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
   group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -2326,8 +2326,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 211 as analysis_id,
@@ -2512,7 +2512,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -2523,8 +2523,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 403 as analysis_id,
@@ -2619,7 +2619,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_406
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_406
@@ -2628,8 +2628,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 406 as analysis_id,
@@ -2856,7 +2856,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
   group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -2865,8 +2865,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 506 as analysis_id,
@@ -2983,7 +2983,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -2994,8 +2994,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 512 as analysis_id,
@@ -3051,7 +3051,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -3062,8 +3062,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 513 as analysis_id,
@@ -3118,7 +3118,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -3129,8 +3129,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 514 as analysis_id,
@@ -3185,7 +3185,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -3196,8 +3196,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 515 as analysis_id,
@@ -3298,7 +3298,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -3309,8 +3309,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 603 as analysis_id,
@@ -3406,7 +3406,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_606
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_606
@@ -3415,8 +3415,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 606 as analysis_id,
@@ -3597,7 +3597,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -3608,8 +3608,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 703 as analysis_id,
@@ -3704,7 +3704,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_706
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_706
@@ -3713,8 +3713,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 706 as analysis_id,
@@ -3844,7 +3844,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
 	group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -3853,8 +3853,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 715 as analysis_id,
@@ -3906,7 +3906,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
 	group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -3915,8 +3915,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 716 as analysis_id,
@@ -3969,7 +3969,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
 	group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -3978,8 +3978,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 717 as analysis_id,
@@ -4097,7 +4097,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -4108,8 +4108,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 803 as analysis_id,
@@ -4207,7 +4207,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_806
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_806
@@ -4216,8 +4216,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 806 as analysis_id,
@@ -4368,7 +4368,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_815
 	group by subject_id, unit_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, unit_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, unit_concept_id order by count_value) as rn
   FROM #rawData_815
@@ -4377,8 +4377,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 815 as analysis_id,
@@ -4522,7 +4522,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -4533,8 +4533,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 903 as analysis_id,
@@ -4617,7 +4617,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_906
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_906
@@ -4626,8 +4626,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 906 as analysis_id,
@@ -4682,7 +4682,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
 		count_value, 
@@ -4694,8 +4694,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 907 as analysis_id,
@@ -4854,7 +4854,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -4865,8 +4865,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 1003 as analysis_id,
@@ -4948,7 +4948,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_1006
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_1006
@@ -4957,8 +4957,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1006 as analysis_id,
@@ -5014,7 +5014,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
 		count_value, 
@@ -5026,8 +5026,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1007 as analysis_id,
@@ -5279,7 +5279,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
   	count_value, 
@@ -5291,8 +5291,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1406 as analysis_id,
@@ -5354,7 +5354,7 @@ overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) a
   FROM rawData
   group by stratum_id
 ),
-stats (stratum_id, count_value, total, rn) as
+statsView (stratum_id, count_value, total, rn) as
 (
   select stratum_id, count_value, count_big(*) as total, row_number() over (order by count_value) as rn
   FROM rawData
@@ -5363,8 +5363,8 @@ stats (stratum_id, count_value, total, rn) as
 priorStats (stratum_id, count_value, total, accumulated) as
 (
   select s.stratum_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum_id = p.stratum_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum_id = p.stratum_id and p.rn <= s.rn
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 1407 as analysis_id,
@@ -5647,7 +5647,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
 		count_value, 
@@ -5659,8 +5659,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1502 as analysis_id,
@@ -5713,7 +5713,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
 		count_value, 
@@ -5725,8 +5725,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1503 as analysis_id,
@@ -5778,7 +5778,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
   	count_value, 
@@ -5790,8 +5790,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1504 as analysis_id,
@@ -5843,7 +5843,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -5855,8 +5855,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1505 as analysis_id,
@@ -5908,7 +5908,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -5920,8 +5920,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1506 as analysis_id,
@@ -5972,7 +5972,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -5984,8 +5984,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1507 as analysis_id,
@@ -6037,7 +6037,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6049,8 +6049,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1508 as analysis_id,
@@ -6102,7 +6102,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6114,8 +6114,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1509 as analysis_id,
@@ -6166,7 +6166,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6178,8 +6178,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1510 as analysis_id,
@@ -6229,7 +6229,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6241,8 +6241,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1511 as analysis_id,
@@ -6353,7 +6353,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6365,8 +6365,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1602 as analysis_id,
@@ -6418,7 +6418,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6430,8 +6430,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1603 as analysis_id,
@@ -6482,7 +6482,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6494,8 +6494,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1604 as analysis_id,
@@ -6546,7 +6546,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6558,8 +6558,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1605 as analysis_id,
@@ -6610,7 +6610,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6622,8 +6622,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1606 as analysis_id,
@@ -6674,7 +6674,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6686,8 +6686,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1607 as analysis_id,
@@ -6739,7 +6739,7 @@ overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) 
   from rawData
   group by stratum1_id
 ),
-stats (stratum1_id, count_value, total, rn) as
+statsView (stratum1_id, count_value, total, rn) as
 (
   select stratum1_id, 
     count_value, 
@@ -6751,8 +6751,8 @@ stats (stratum1_id, count_value, total, rn) as
 priorStats (stratum1_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1608 as analysis_id,
@@ -6916,7 +6916,7 @@ overallStats (avg_value, stdev_value, min_value, max_value, total) as
     count_big(*) as total
   from rawData
 ),
-stats (count_value, total, rn) as
+statsView (count_value, total, rn) as
 (
   select count_value, 
   	count_big(*) as total, 
@@ -6927,8 +6927,8 @@ stats (count_value, total, rn) as
 priorStats (count_value, total, accumulated) as
 (
   select s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on p.rn <= s.rn
+  from statsView s
+  join statsView p on p.rn <= s.rn
   group by s.count_value, s.total, s.rn
 )
 select 1803 as analysis_id,
@@ -7023,7 +7023,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_1806
 	group by subject_id, gender_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, gender_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, gender_concept_id order by count_value) as rn
   FROM #rawData_1806
@@ -7032,8 +7032,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1806 as analysis_id,
@@ -7170,7 +7170,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_1815
 	group by subject_id, unit_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, unit_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, unit_concept_id order by count_value) as rn
   FROM #rawData_1815
@@ -7179,8 +7179,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1815 as analysis_id,
@@ -7241,7 +7241,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_1816
 	group by subject_id, unit_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, unit_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, unit_concept_id order by count_value) as rn
   FROM #rawData_1816
@@ -7250,8 +7250,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1816 as analysis_id,
@@ -7312,7 +7312,7 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
   FROM #rawData_1817
 	group by subject_id, unit_concept_id
 ),
-stats (stratum1_id, stratum2_id, count_value, total, rn) as
+statsView (stratum1_id, stratum2_id, count_value, total, rn) as
 (
   select subject_id as stratum1_id, unit_concept_id as stratum2_id, count_value, count_big(*) as total, row_number() over (partition by subject_id, unit_concept_id order by count_value) as rn
   FROM #rawData_1817
@@ -7321,8 +7321,8 @@ stats (stratum1_id, stratum2_id, count_value, total, rn) as
 priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
 (
   select s.stratum1_id, s.stratum2_id, s.count_value, s.total, sum(p.total) as accumulated
-  from stats s
-  join stats p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
+  from statsView s
+  join statsView p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1817 as analysis_id,

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -294,7 +294,7 @@ SELECT
 		location_source_value,
     row_number() over (order by location_id) rn
 FROM
-		@cdm_database_schema.location
+		@cdm_database_schema.`location`
 ) location
 WHERE rn = 1;
 
@@ -1368,7 +1368,7 @@ where p1.provider_id is not null
 insert into @results_database_schema.ACHILLES_results (analysis_id, count_value)
 select 8 as analysis_id,  COUNT_BIG(p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	left join @cdm_database_schema.location l1
+	left join @cdm_database_schema.`location` l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.location_id is null
@@ -5130,7 +5130,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1100 as analysis_id,  
 	left(l1.zip,3) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	inner join @cdm_database_schema.LOCATION l1
+	inner join @cdm_database_schema.`location` l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.zip is not null
@@ -5144,7 +5144,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1101 as analysis_id,  
 	l1.state as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	inner join @cdm_database_schema.LOCATION l1
+	inner join @cdm_database_schema.`location` l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.state is not null
@@ -5158,7 +5158,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1102 as analysis_id,  
 	left(l1.zip,3) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
-	inner join @cdm_database_schema.LOCATION l1
+	inner join @cdm_database_schema.`location` l1
 	on cs1.location_id = l1.location_id
 where cs1.location_id is not null
 	and l1.zip is not null
@@ -5172,7 +5172,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1103 as analysis_id,  
 	l1.state as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
-	inner join @cdm_database_schema.LOCATION l1
+	inner join @cdm_database_schema.`location` l1
 	on cs1.location_id = l1.location_id
 where cs1.location_id is not null
 	and l1.state is not null

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -3954,7 +3954,7 @@ drop table #tempResults;
 with rawData(stratum_id, count_value) as
 (
   select drug_concept_id,
-    quantity as count_value
+    CAST(quantity AS FLOAT) as count_value
   from @cdm_database_schema.drug_exposure 
 	where quantity is not null
 ),
@@ -4349,7 +4349,7 @@ where o1.value_as_number is null
 -- 815  Distribution of numeric values, by observation_concept_id and unit_concept_id
 select observation_concept_id as subject_id, 
 	unit_concept_id,
-	value_as_number as count_value
+	CAST(value_as_number AS FLOAT) as count_value
 INTO #rawData_815
 from @cdm_database_schema.observation o1
 where o1.unit_concept_id is not null
@@ -7151,7 +7151,7 @@ where m.value_as_number is null
 -- 1815  Distribution of numeric values, by measurement_concept_id and unit_concept_id
 select measurement_concept_id as subject_id, 
 	unit_concept_id,
-	value_as_number as count_value
+	CAST(value_as_number AS FLOAT) as count_value
 INTO #rawData_1815
 from @cdm_database_schema.measurement m
 where m.unit_concept_id is not null
@@ -7220,7 +7220,7 @@ drop table #tempResults;
 -- 1816	Distribution of low range, by measurement_concept_id and unit_concept_id
 select measurement_concept_id as subject_id, 
 	unit_concept_id,
-	range_low as count_value
+	CAST(range_low AS FLOAT) as count_value
 INTO #rawData_1816
 from @cdm_database_schema.measurement m
 where m.unit_concept_id is not null
@@ -7291,7 +7291,7 @@ drop table #tempResults;
 -- 1817	Distribution of high range, by observation_concept_id and unit_concept_id
 select measurement_concept_id as subject_id, 
 	unit_concept_id,
-	range_high as count_value
+	CAST(range_high AS FLOAT) as count_value
 INTO #rawData_1817
 from @cdm_database_schema.measurement m
 where m.unit_concept_id is not null

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -1463,8 +1463,8 @@ select p.person_id,
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * age_value) as avg_value,
-  stdev(age_value) as stdev_value,
+  select CAST(avg(1.0 * age_value) AS FLOAT) as avg_value,
+  CAST(stdev(age_value) AS FLOAT) as stdev_value,
   min(age_value) as min_value,
   max(age_value) as max_value,
   count_big(*) as total
@@ -1523,8 +1523,8 @@ with rawData (gender_concept_id, age_value) as
 overallStats (gender_concept_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select gender_concept_id,
-  avg(1.0 *age_value) as avg_value,
-  stdev(age_value) as stdev_value,
+  CAST(avg(1.0 * age_value) AS FLOAT) as avg_value,
+  CAST(stdev(age_value) AS FLOAT) as stdev_value,
   min(age_value) as min_value,
   max(age_value) as max_value,
   count_big(*) as total
@@ -1586,8 +1586,8 @@ with rawData (count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-  stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+  CAST(stdev(count_value) AS FLOAT) as stdev_value,
   min(count_value) as min_value,
   max(count_value) as max_value,
   count_big(*) as total
@@ -1656,8 +1656,8 @@ with rawData(gender_concept_id, count_value) as
 overallStats (gender_concept_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select gender_concept_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -1726,8 +1726,8 @@ with rawData (age_decile, count_value) as
 overallStats (age_decile, avg_value, stdev_value, min_value, max_value, total) as
 (
   select age_decile,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2098,8 +2098,8 @@ with rawData(person_id, count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2193,8 +2193,8 @@ overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, max_v
 (
   select stratum1_id,
     stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2309,8 +2309,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2505,8 +2505,8 @@ with rawData(person_id, count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2611,8 +2611,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2848,8 +2848,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -2937,8 +2937,8 @@ select 511 as analysis_id,
   COUNT_BIG(count_value) as count_value,
 	min(count_value) as min_value,
 	max(count_value) as max_value,
-	avg(1.0*count_value) as avg_value,
-	stdev(count_value) as stdev_value,
+	CAST(avg(1.0*count_value) AS FLOAT) as avg_value,
+	CAST(stdev(count_value) AS FLOAT) as stdev_value,
 	max(case when p1<=0.50 then count_value else -9999 end) as median_value,
 	max(case when p1<=0.10 then count_value else -9999 end) as p10_value,
 	max(case when p1<=0.25 then count_value else -9999 end) as p25_value,
@@ -2976,8 +2976,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3044,8 +3044,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3111,8 +3111,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3178,8 +3178,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3291,8 +3291,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3398,8 +3398,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3590,8 +3590,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3696,8 +3696,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3836,8 +3836,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3898,8 +3898,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -3961,8 +3961,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4090,8 +4090,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4199,8 +4199,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4360,8 +4360,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     unit_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4515,8 +4515,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4609,8 +4609,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4674,8 +4674,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-  	avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  	CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4847,8 +4847,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -4940,8 +4940,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5006,8 +5006,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5271,8 +5271,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5346,8 +5346,8 @@ with rawData(stratum_id, count_value) as
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5639,8 +5639,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5705,8 +5705,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5770,8 +5770,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5835,8 +5835,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5900,8 +5900,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -5964,8 +5964,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6029,8 +6029,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6094,8 +6094,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6158,8 +6158,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6221,8 +6221,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6345,8 +6345,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6410,8 +6410,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6474,8 +6474,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6538,8 +6538,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6602,8 +6602,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6666,8 +6666,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6731,8 +6731,8 @@ with rawData(stratum1_id, count_value) as
 overallStats (stratum1_id, avg_value, stdev_value, min_value, max_value, total) as
 (
   select stratum1_id, 
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -6909,8 +6909,8 @@ with rawData(count_value) as
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (
-  select avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+  select CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -7015,8 +7015,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     gender_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -7162,8 +7162,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     unit_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -7233,8 +7233,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     unit_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total
@@ -7304,8 +7304,8 @@ with overallStats (stratum1_id, stratum2_id, avg_value, stdev_value, min_value, 
 (
   select subject_id as stratum1_id,
     unit_concept_id as stratum2_id,
-    avg(1.0 * count_value) as avg_value,
-    stdev(count_value) as stdev_value,
+    CAST(avg(1.0 * count_value) AS FLOAT) as avg_value,
+    CAST(stdev(count_value) AS FLOAT) as stdev_value,
     min(count_value) as min_value,
     max(count_value) as max_value,
     count_big(*) as total

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -1282,11 +1282,11 @@ delete from @results_database_schema.ACHILLES_results_dist where analysis_id IN 
 --{0 IN (@list_of_analysis_ids)}?{
 -- 0	cdm name, version of Achilles and date when pre-computations were executed
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3,count_value)
-select 0 as analysis_id,  '@source_name' as stratum_1, '@achilles_version' as stratum_2, GETDATE() as stratum_3,COUNT_BIG(distinct person_id) as count_value
+select 0 as analysis_id,  CAST('@source_name' AS VARCHAR(255)) as stratum_1, CAST('@achilles_version' AS VARCHAR(255)) as stratum_2, CAST(GETDATE() AS VARCHAR(255)) as stratum_3,COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON;
 
 insert into @results_database_schema.ACHILLES_results_dist (analysis_id, stratum_1, count_value)
-select 0 as analysis_id, '@source_name' as stratum_1, COUNT_BIG(distinct person_id) as count_value
+select 0 as analysis_id, CAST('@source_name' AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON;
 
 --}
@@ -1311,7 +1311,7 @@ from @cdm_database_schema.PERSON;
 --{2 IN (@list_of_analysis_ids)}?{
 -- 2	Number of persons by gender
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 2 as analysis_id,  gender_concept_id as stratum_1, COUNT_BIG(distinct person_id) as count_value
+select 2 as analysis_id,  CAST(gender_concept_id AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by GENDER_CONCEPT_ID;
 --}
@@ -1321,7 +1321,7 @@ group by GENDER_CONCEPT_ID;
 --{3 IN (@list_of_analysis_ids)}?{
 -- 3	Number of persons by year of birth
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 3 as analysis_id,  year_of_birth as stratum_1, COUNT_BIG(distinct person_id) as count_value
+select 3 as analysis_id,  CAST(year_of_birth AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by YEAR_OF_BIRTH;
 --}
@@ -1330,7 +1330,7 @@ group by YEAR_OF_BIRTH;
 --{4 IN (@list_of_analysis_ids)}?{
 -- 4	Number of persons by race
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 4 as analysis_id,  RACE_CONCEPT_ID as stratum_1, COUNT_BIG(distinct person_id) as count_value
+select 4 as analysis_id,  CAST(RACE_CONCEPT_ID AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by RACE_CONCEPT_ID;
 --}
@@ -1340,7 +1340,7 @@ group by RACE_CONCEPT_ID;
 --{5 IN (@list_of_analysis_ids)}?{
 -- 5	Number of persons by ethnicity
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 5 as analysis_id,  ETHNICITY_CONCEPT_ID as stratum_1, COUNT_BIG(distinct person_id) as count_value
+select 5 as analysis_id,  CAST(ETHNICITY_CONCEPT_ID AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by ETHNICITY_CONCEPT_ID;
 --}
@@ -1393,8 +1393,8 @@ where p1.care_site_id is not null
 --{10 IN (@list_of_analysis_ids)}?{
 -- 10	Number of all persons by year of birth and by gender
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 10 as analysis_id,  year_of_birth as stratum_1, 
-  gender_concept_id as stratum_2,
+select 10 as analysis_id,  CAST(year_of_birth AS VARCHAR(255)) as stratum_1,
+  CAST(gender_concept_id AS VARCHAR(255)) as stratum_2,
   COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by YEAR_OF_BIRTH, gender_concept_id;
@@ -1404,8 +1404,8 @@ group by YEAR_OF_BIRTH, gender_concept_id;
 --{11 IN (@list_of_analysis_ids)}?{
 -- 11	Number of non-deceased persons by year of birth and by gender
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 11 as analysis_id,  year_of_birth as stratum_1, 
-  gender_concept_id as stratum_2,
+select 11 as analysis_id,  CAST(year_of_birth AS VARCHAR(255)) as stratum_1,
+  CAST(gender_concept_id AS VARCHAR(255)) as stratum_2,
   COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 where person_id not in (select person_id from @cdm_database_schema.DEATH)
@@ -1417,7 +1417,7 @@ group by YEAR_OF_BIRTH, gender_concept_id;
 --{12 IN (@list_of_analysis_ids)}?{
 -- 12	Number of persons by race and ethnicity
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 12 as analysis_id, RACE_CONCEPT_ID as stratum_1, ETHNICITY_CONCEPT_ID as stratum_2, COUNT_BIG(distinct person_id) as count_value
+select 12 as analysis_id, CAST(RACE_CONCEPT_ID AS VARCHAR(255)) as stratum_1, CAST(ETHNICITY_CONCEPT_ID AS VARCHAR(255)) as stratum_2, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON
 group by RACE_CONCEPT_ID,ETHNICITY_CONCEPT_ID;
 --}
@@ -1431,7 +1431,7 @@ ACHILLES Analyses on OBSERVATION_PERIOD table
 --{101 IN (@list_of_analysis_ids)}?{
 -- 101	Number of persons by age, with age at first observation period
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 101 as analysis_id,   year(op1.index_date) - p1.YEAR_OF_BIRTH as stratum_1, COUNT_BIG(p1.person_id) as count_value
+select 101 as analysis_id,   CAST(year(op1.index_date) - p1.YEAR_OF_BIRTH AS VARCHAR(255)) as stratum_1, COUNT_BIG(p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join (select person_id, MIN(observation_period_start_date) as index_date from @cdm_database_schema.OBSERVATION_PERIOD group by PERSON_ID) op1
 	on p1.PERSON_ID = op1.PERSON_ID
@@ -1443,7 +1443,7 @@ group by year(op1.index_date) - p1.YEAR_OF_BIRTH;
 --{102 IN (@list_of_analysis_ids)}?{
 -- 102	Number of persons by gender by age, with age at first observation period
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 102 as analysis_id,  p1.gender_concept_id as stratum_1, year(op1.index_date) - p1.YEAR_OF_BIRTH as stratum_2, COUNT_BIG(p1.person_id) as count_value
+select 102 as analysis_id,  CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_1, CAST(year(op1.index_date) - p1.YEAR_OF_BIRTH AS VARCHAR(255)) as stratum_2, COUNT_BIG(p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join (select person_id, MIN(observation_period_start_date) as index_date from @cdm_database_schema.OBSERVATION_PERIOD group by PERSON_ID) op1
 	on p1.PERSON_ID = op1.PERSON_ID
@@ -1545,7 +1545,7 @@ ageStatsPrior (gender_concept_id, age_value, total, accumulated) as
   group by s.gender_concept_id, s.age_value, s.total, s.rn
 )
 select 104 as analysis_id,
-  o.gender_concept_id as stratum_1,
+  CAST(o.gender_concept_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -1678,7 +1678,7 @@ priorStats (gender_concept_id,count_value, total, accumulated) as
   group by s.gender_concept_id, s.count_value, s.total, s.rn
 )
 select 106 as analysis_id,
-  o.gender_concept_id,
+  CAST(o.gender_concept_id AS VARCHAR(255)) as gender_concept_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -1751,7 +1751,7 @@ priorStats (age_decile,count_value, total, accumulated) as
   group by s.age_decile, s.count_value, s.total, s.rn
 )
 select 107 as analysis_id,
-  o.age_decile,
+  CAST(o.age_decile AS VARCHAR(255)) as age_decile,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -1782,7 +1782,7 @@ drop table #tempResults;
 --{108 IN (@list_of_analysis_ids)}?{
 -- 108	Number of persons by length of observation period, in 30d increments
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 108 as analysis_id,  floor(DATEDIFF(dd, op1.observation_period_start_date, op1.observation_period_end_date)/30) as stratum_1, COUNT_BIG(distinct p1.person_id) as count_value
+select 108 as analysis_id,  CAST(floor(DATEDIFF(dd, op1.observation_period_start_date, op1.observation_period_end_date)/30) AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join 
 	(select person_id, 
@@ -1819,7 +1819,7 @@ FROM @cdm_database_schema.observation_period
 INSERT INTO @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 SELECT 
   109 AS analysis_id,  
-	obs_year AS stratum_1, 
+	CAST(obs_year AS VARCHAR(255)) AS stratum_1,
 	COUNT_BIG(DISTINCT person_id) AS count_value
 FROM @cdm_database_schema.observation_period,
 	#temp_dates
@@ -1856,7 +1856,7 @@ FROM @cdm_database_schema.observation_period
 INSERT INTO @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 SELECT 
   110 AS analysis_id, 
-	obs_month AS stratum_1, 
+	CAST(obs_month AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(DISTINCT person_id) AS count_value
 FROM
 	@cdm_database_schema.observation_period,
@@ -1879,7 +1879,7 @@ DROP TABLE #temp_dates;
 -- 111	Number of persons by observation period start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 111 as analysis_id, 
-	YEAR(observation_period_start_date)*100 + month(OBSERVATION_PERIOD_START_DATE) as stratum_1, 
+	CAST(YEAR(observation_period_start_date)*100 + month(OBSERVATION_PERIOD_START_DATE) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct op1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation_period op1
@@ -1893,7 +1893,7 @@ group by YEAR(observation_period_start_date)*100 + month(OBSERVATION_PERIOD_STAR
 -- 112	Number of persons by observation period end month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 112 as analysis_id,  
-	YEAR(observation_period_end_date)*100 + month(observation_period_end_date) as stratum_1, 
+	CAST(YEAR(observation_period_end_date)*100 + month(observation_period_end_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct op1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation_period op1
@@ -1906,7 +1906,7 @@ group by YEAR(observation_period_end_date)*100 + month(observation_period_end_da
 -- 113	Number of persons by number of observation periods
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 113 as analysis_id,  
-	op1.num_periods as stratum_1, COUNT_BIG(distinct op1.PERSON_ID) as count_value
+	CAST(op1.num_periods AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct op1.PERSON_ID) as count_value
 from
 	(select person_id, COUNT_BIG(OBSERVATION_period_start_date) as num_periods from @cdm_database_schema.OBSERVATION_PERIOD group by PERSON_ID) op1
 group by op1.num_periods
@@ -1956,9 +1956,9 @@ from
 
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
 select 116 as analysis_id,  
-	t1.obs_year as stratum_1, 
-	p1.gender_concept_id as stratum_2,
-	floor((t1.obs_year - p1.year_of_birth)/10) as stratum_3,
+	CAST(t1.obs_year AS VARCHAR(255)) as stratum_1,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_2,
+	CAST(floor((t1.obs_year - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_3,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
@@ -1996,7 +1996,7 @@ from
 
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 117 as analysis_id,  
-	t1.obs_month as stratum_1,
+	CAST(t1.obs_month AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct op1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation_period op1,
@@ -2028,7 +2028,7 @@ where p1.person_id is null
 -- 119  Number of observation period records by period_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1,count_value)
 select 119 as analysis_id,
-  op1.period_type_concept_id as stratum_1,
+  CAST(op1.period_type_concept_id AS VARCHAR(255)) as stratum_1,
   COUNT_BIG(*) as count_value
 from
   @cdm_database_schema.observation_period op1
@@ -2048,7 +2048,7 @@ ACHILLES Analyses on VISIT_OCCURRENCE table
 -- 200	Number of persons with at least one visit occurrence, by visit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 200 as analysis_id, 
-	vo1.visit_concept_id as stratum_1,
+	CAST(vo1.visit_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct vo1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.visit_occurrence vo1
@@ -2061,7 +2061,7 @@ group by vo1.visit_concept_id
 -- 201	Number of visit occurrence records, by visit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 201 as analysis_id, 
-	vo1.visit_concept_id as stratum_1,
+	CAST(vo1.visit_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(vo1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.visit_occurrence vo1
@@ -2075,8 +2075,8 @@ group by vo1.visit_concept_id
 -- 202	Number of persons by visit occurrence start month, by visit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 202 as analysis_id,   
-	vo1.visit_concept_id as stratum_1,
-	YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_2, 
+	CAST(vo1.visit_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(visit_start_date)*100 + month(visit_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.visit_occurrence vo1
@@ -2153,10 +2153,10 @@ drop table #tempResults;
 -- 204	Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 204 as analysis_id,   
-	vo1.visit_concept_id as stratum_1,
-	YEAR(visit_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(visit_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(vo1.visit_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(visit_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(visit_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -2215,8 +2215,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 206 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -2331,7 +2331,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 211 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -2383,7 +2383,7 @@ group by
 -- 220	Number of visit occurrence records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 220 as analysis_id,   
-	YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_1, 
+	CAST(YEAR(visit_start_date)*100 + month(visit_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.visit_occurrence vo1
@@ -2396,7 +2396,7 @@ group by YEAR(visit_start_date)*100 + month(visit_start_date)
 -- 221	Number of persons by visit start year 
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 221 as analysis_id,   
-	YEAR(visit_start_date) as stratum_1, 
+	CAST(YEAR(visit_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.visit_occurrence vo1
@@ -2426,7 +2426,7 @@ from @cdm_database_schema.provider;
 --{301 IN (@list_of_analysis_ids)}?{
 -- 301	Number of providers by specialty concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
-select 301 as analysis_id,  specialty_concept_id as stratum_1, COUNT_BIG(distinct provider_id) as count_value
+select 301 as analysis_id,  CAST(specialty_concept_id AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct provider_id) as count_value
 from @cdm_database_schema.provider
 group by specialty_CONCEPT_ID;
 --}
@@ -2456,7 +2456,7 @@ ACHILLES Analyses on CONDITION_OCCURRENCE table
 -- 400	Number of persons with at least one condition occurrence, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 400 as analysis_id, 
-	co1.condition_CONCEPT_ID as stratum_1,
+	CAST(co1.condition_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct co1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.condition_occurrence co1
@@ -2469,7 +2469,7 @@ group by co1.condition_CONCEPT_ID
 -- 401	Number of condition occurrence records, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 401 as analysis_id, 
-	co1.condition_CONCEPT_ID as stratum_1,
+	CAST(co1.condition_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(co1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.condition_occurrence co1
@@ -2483,8 +2483,8 @@ group by co1.condition_CONCEPT_ID
 -- 402	Number of persons by condition occurrence start month, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 402 as analysis_id,   
-	co1.condition_concept_id as stratum_1,
-	YEAR(condition_start_date)*100 + month(condition_start_date) as stratum_2, 
+	CAST(co1.condition_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(condition_start_date)*100 + month(condition_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.condition_occurrence co1
@@ -2560,10 +2560,10 @@ drop table #tempResults;
 -- 404	Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 404 as analysis_id,   
-	co1.condition_concept_id as stratum_1,
-	YEAR(condition_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(condition_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(co1.condition_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(condition_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(condition_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -2580,8 +2580,8 @@ group by co1.condition_concept_id,
 -- 405	Number of condition occurrence records, by condition_concept_id by condition_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 405 as analysis_id, 
-	co1.condition_CONCEPT_ID as stratum_1,
-	co1.condition_type_concept_id as stratum_2,
+	CAST(co1.condition_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(co1.condition_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(co1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.condition_occurrence co1
@@ -2633,8 +2633,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 406 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -2739,7 +2739,7 @@ where co1.visit_occurrence_id is not null
 -- 420	Number of condition occurrence records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 420 as analysis_id,   
-	YEAR(condition_start_date)*100 + month(condition_start_date) as stratum_1, 
+	CAST(YEAR(condition_start_date)*100 + month(condition_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.condition_occurrence co1
@@ -2761,7 +2761,7 @@ ACHILLES Analyses on DEATH table
 -- 500	Number of persons with death, by cause_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 500 as analysis_id, 
-	d1.cause_concept_id as stratum_1,
+	CAST(d1.cause_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct d1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.death d1
@@ -2774,7 +2774,7 @@ group by d1.cause_concept_id
 -- 501	Number of records of death, by cause_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 501 as analysis_id, 
-	d1.cause_concept_id as stratum_1,
+	CAST(d1.cause_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(d1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.death d1
@@ -2788,7 +2788,7 @@ group by d1.cause_concept_id
 -- 502	Number of persons by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 502 as analysis_id,   
-	YEAR(death_date)*100 + month(death_date) as stratum_1, 
+	CAST(YEAR(death_date)*100 + month(death_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.death d1
@@ -2802,9 +2802,9 @@ group by YEAR(death_date)*100 + month(death_date)
 -- 504	Number of persons with a death, by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
 select 504 as analysis_id,   
-	YEAR(death_date) as stratum_1,
-	p1.gender_concept_id as stratum_2,
-	floor((year(death_date) - p1.year_of_birth)/10) as stratum_3, 
+	CAST(YEAR(death_date) AS VARCHAR(255)) as stratum_1,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_2,
+	CAST(floor((year(death_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_3,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -2820,7 +2820,7 @@ group by YEAR(death_date),
 -- 505	Number of death records, by death_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 505 as analysis_id, 
-	death_type_concept_id as stratum_1,
+	CAST(death_type_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 	@cdm_database_schema.death d1
@@ -2870,7 +2870,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 506 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -3242,7 +3242,7 @@ ACHILLES Analyses on PROCEDURE_OCCURRENCE table
 -- 600	Number of persons with at least one procedure occurrence, by procedure_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 600 as analysis_id, 
-	po1.procedure_CONCEPT_ID as stratum_1,
+	CAST(po1.procedure_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct po1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.procedure_occurrence po1
@@ -3255,7 +3255,7 @@ group by po1.procedure_CONCEPT_ID
 -- 601	Number of procedure occurrence records, by procedure_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 601 as analysis_id, 
-	po1.procedure_CONCEPT_ID as stratum_1,
+	CAST(po1.procedure_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(po1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.procedure_occurrence po1
@@ -3269,8 +3269,8 @@ group by po1.procedure_CONCEPT_ID
 -- 602	Number of persons by procedure occurrence start month, by procedure_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 602 as analysis_id,   
-	po1.procedure_concept_id as stratum_1,
-	YEAR(procedure_date)*100 + month(procedure_date) as stratum_2, 
+	CAST(po1.procedure_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(procedure_date)*100 + month(procedure_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.procedure_occurrence po1
@@ -3347,10 +3347,10 @@ drop table #tempResults;
 -- 604	Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 604 as analysis_id,   
-	po1.procedure_concept_id as stratum_1,
-	YEAR(procedure_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(procedure_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(po1.procedure_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(procedure_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(procedure_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -3367,8 +3367,8 @@ group by po1.procedure_concept_id,
 -- 605	Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 605 as analysis_id, 
-	po1.procedure_CONCEPT_ID as stratum_1,
-	po1.procedure_type_concept_id as stratum_2,
+	CAST(po1.procedure_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(po1.procedure_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(po1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.procedure_occurrence po1
@@ -3420,8 +3420,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 606 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -3514,7 +3514,7 @@ where po1.visit_occurrence_id is not null
 -- 620	Number of procedure occurrence records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 620 as analysis_id,   
-	YEAR(procedure_date)*100 + month(procedure_date) as stratum_1, 
+	CAST(YEAR(procedure_date)*100 + month(procedure_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.procedure_occurrence po1
@@ -3536,7 +3536,7 @@ ACHILLES Analyses on DRUG_EXPOSURE table
 -- 700	Number of persons with at least one drug occurrence, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 700 as analysis_id, 
-	de1.drug_CONCEPT_ID as stratum_1,
+	CAST(de1.drug_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct de1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.drug_exposure de1
@@ -3549,7 +3549,7 @@ group by de1.drug_CONCEPT_ID
 -- 701	Number of drug occurrence records, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 701 as analysis_id, 
-	de1.drug_CONCEPT_ID as stratum_1,
+	CAST(de1.drug_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(de1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.drug_exposure de1
@@ -3563,8 +3563,8 @@ group by de1.drug_CONCEPT_ID
 -- 702	Number of persons by drug occurrence start month, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 702 as analysis_id,   
-	de1.drug_concept_id as stratum_1,
-	YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) as stratum_2, 
+	CAST(de1.drug_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.drug_exposure de1
@@ -3645,10 +3645,10 @@ drop table #tempResults;
 -- 704	Number of persons with at least one drug occurrence, by drug_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 704 as analysis_id,   
-	de1.drug_concept_id as stratum_1,
-	YEAR(drug_exposure_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(drug_exposure_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(de1.drug_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(drug_exposure_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(drug_exposure_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -3665,8 +3665,8 @@ group by de1.drug_concept_id,
 -- 705	Number of drug occurrence records, by drug_concept_id by drug_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 705 as analysis_id, 
-	de1.drug_CONCEPT_ID as stratum_1,
-	de1.drug_type_concept_id as stratum_2,
+	CAST(de1.drug_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(de1.drug_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(de1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.drug_exposure de1
@@ -3718,8 +3718,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 706 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -3858,7 +3858,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 715 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -3920,7 +3920,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 716 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -3983,7 +3983,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 717 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -4016,7 +4016,7 @@ drop table #tempResults;
 -- 720	Number of drug exposure records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 720 as analysis_id,   
-	YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) as stratum_1, 
+	CAST(YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.drug_exposure de1
@@ -4036,7 +4036,7 @@ ACHILLES Analyses on OBSERVATION table
 -- 800	Number of persons with at least one observation occurrence, by observation_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 800 as analysis_id, 
-	o1.observation_CONCEPT_ID as stratum_1,
+	CAST(o1.observation_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct o1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation o1
@@ -4049,7 +4049,7 @@ group by o1.observation_CONCEPT_ID
 -- 801	Number of observation occurrence records, by observation_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 801 as analysis_id, 
-	o1.observation_CONCEPT_ID as stratum_1,
+	CAST(o1.observation_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(o1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation o1
@@ -4063,8 +4063,8 @@ group by o1.observation_CONCEPT_ID
 -- 802	Number of persons by observation occurrence start month, by observation_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 802 as analysis_id,   
-	o1.observation_concept_id as stratum_1,
-	YEAR(observation_date)*100 + month(observation_date) as stratum_2, 
+	CAST(o1.observation_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(observation_date)*100 + month(observation_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.observation o1
@@ -4147,10 +4147,10 @@ drop table #tempResults;
 -- 804	Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 804 as analysis_id,   
-	o1.observation_concept_id as stratum_1,
-	YEAR(observation_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(observation_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(o1.observation_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(observation_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(observation_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -4167,8 +4167,8 @@ group by o1.observation_concept_id,
 -- 805	Number of observation occurrence records, by observation_concept_id by observation_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 805 as analysis_id, 
-	o1.observation_CONCEPT_ID as stratum_1,
-	o1.observation_type_concept_id as stratum_2,
+	CAST(o1.observation_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(o1.observation_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(o1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation o1
@@ -4221,8 +4221,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 806 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -4257,8 +4257,8 @@ drop table #tempResults;
 -- 807	Number of observation occurrence records, by observation_concept_id and unit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 807 as analysis_id, 
-	o1.observation_CONCEPT_ID as stratum_1,
-	o1.unit_concept_id as stratum_2,
+	CAST(o1.observation_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
+	CAST(o1.unit_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(o1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.observation o1
@@ -4382,8 +4382,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 815 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -4444,7 +4444,7 @@ drop table #tempResults;
 -- 820	Number of observation records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 820 as analysis_id,   
-	YEAR(observation_date)*100 + month(observation_date) as stratum_1, 
+	CAST(YEAR(observation_date)*100 + month(observation_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.observation o1
@@ -4466,7 +4466,7 @@ ACHILLES Analyses on DRUG_ERA table
 -- 900	Number of persons with at least one drug occurrence, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 900 as analysis_id, 
-	de1.drug_CONCEPT_ID as stratum_1,
+	CAST(de1.drug_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct de1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.drug_era de1
@@ -4479,7 +4479,7 @@ group by de1.drug_CONCEPT_ID
 -- 901	Number of drug occurrence records, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 901 as analysis_id, 
-	de1.drug_CONCEPT_ID as stratum_1,
+	CAST(de1.drug_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(de1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.drug_era de1
@@ -4493,8 +4493,8 @@ group by de1.drug_CONCEPT_ID
 -- 902	Number of persons by drug occurrence start month, by drug_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 902 as analysis_id,   
-	de1.drug_concept_id as stratum_1,
-	YEAR(drug_era_start_date)*100 + month(drug_era_start_date) as stratum_2, 
+	CAST(de1.drug_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(drug_era_start_date)*100 + month(drug_era_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.drug_era de1
@@ -4571,10 +4571,10 @@ drop table #tempResults;
 -- 904	Number of persons with at least one drug occurrence, by drug_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 904 as analysis_id,   
-	de1.drug_concept_id as stratum_1,
-	YEAR(drug_era_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(drug_era_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(de1.drug_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(drug_era_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(drug_era_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -4631,8 +4631,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 906 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -4699,7 +4699,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 907 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -4775,7 +4775,7 @@ where de1.drug_era_end_date < de1.drug_era_start_date
 -- 920	Number of drug era records by drug era start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 920 as analysis_id,   
-	YEAR(drug_era_start_date)*100 + month(drug_era_start_date) as stratum_1, 
+	CAST(YEAR(drug_era_start_date)*100 + month(drug_era_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.drug_era de1
@@ -4798,7 +4798,7 @@ ACHILLES Analyses on CONDITION_ERA table
 -- 1000	Number of persons with at least one condition occurrence, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1000 as analysis_id, 
-	ce1.condition_CONCEPT_ID as stratum_1,
+	CAST(ce1.condition_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct ce1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.condition_era ce1
@@ -4811,7 +4811,7 @@ group by ce1.condition_CONCEPT_ID
 -- 1001	Number of condition occurrence records, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1001 as analysis_id, 
-	ce1.condition_CONCEPT_ID as stratum_1,
+	CAST(ce1.condition_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(ce1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.condition_era ce1
@@ -4825,8 +4825,8 @@ group by ce1.condition_CONCEPT_ID
 -- 1002	Number of persons by condition occurrence start month, by condition_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 1002 as analysis_id,   
-	ce1.condition_concept_id as stratum_1,
-	YEAR(condition_era_start_date)*100 + month(condition_era_start_date) as stratum_2, 
+	CAST(ce1.condition_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(condition_era_start_date)*100 + month(condition_era_start_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 @cdm_database_schema.condition_era ce1
@@ -4902,10 +4902,10 @@ drop table #tempResults;
 -- 1004	Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 1004 as analysis_id,   
-	ce1.condition_concept_id as stratum_1,
-	YEAR(condition_era_start_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(condition_era_start_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(ce1.condition_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(condition_era_start_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(condition_era_start_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join
@@ -4962,8 +4962,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1006 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5031,7 +5031,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1007 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5107,7 +5107,7 @@ where ce1.condition_era_end_date < ce1.condition_era_start_date
 -- 1020	Number of drug era records by drug era start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1020 as analysis_id,   
-	YEAR(condition_era_start_date)*100 + month(condition_era_start_date) as stratum_1, 
+	CAST(YEAR(condition_era_start_date)*100 + month(condition_era_start_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from
 @cdm_database_schema.condition_era ce1
@@ -5128,7 +5128,7 @@ ACHILLES Analyses on LOCATION table
 -- 1100	Number of persons by location 3-digit zip
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1100 as analysis_id,  
-	left(l1.zip,3) as stratum_1, COUNT_BIG(distinct person_id) as count_value
+	CAST(left(l1.zip,3) AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join @cdm_database_schema.`location` l1
 	on p1.location_id = l1.location_id
@@ -5142,7 +5142,7 @@ group by left(l1.zip,3);
 -- 1101	Number of persons by location state
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1101 as analysis_id,  
-	l1.state as stratum_1, COUNT_BIG(distinct person_id) as count_value
+	CAST(l1.state AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join @cdm_database_schema.`location` l1
 	on p1.location_id = l1.location_id
@@ -5156,7 +5156,7 @@ group by l1.state;
 -- 1102	Number of care sites by location 3-digit zip
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1102 as analysis_id,  
-	left(l1.zip,3) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
+	CAST(left(l1.zip,3) AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
 	inner join @cdm_database_schema.`location` l1
 	on cs1.location_id = l1.location_id
@@ -5170,7 +5170,7 @@ group by left(l1.zip,3);
 -- 1103	Number of care sites by location state
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1103 as analysis_id,  
-	l1.state as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
+	CAST(l1.state AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
 	inner join @cdm_database_schema.`location` l1
 	on cs1.location_id = l1.location_id
@@ -5191,7 +5191,7 @@ ACHILLES Analyses on CARE_SITE table
 -- 1200	Number of persons by place of service
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1200 as analysis_id,  
-	cs1.place_of_service_concept_id as stratum_1, COUNT_BIG(person_id) as count_value
+	CAST(cs1.place_of_service_concept_id AS VARCHAR(255)) as stratum_1, COUNT_BIG(person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join @cdm_database_schema.care_site cs1
 	on p1.care_site_id = cs1.care_site_id
@@ -5205,7 +5205,7 @@ group by cs1.place_of_service_concept_id;
 -- 1201	Number of visits by place of service
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1201 as analysis_id,  
-	cs1.place_of_service_concept_id as stratum_1, COUNT_BIG(visit_occurrence_id) as count_value
+	CAST(cs1.place_of_service_concept_id AS VARCHAR(255)) as stratum_1, COUNT_BIG(visit_occurrence_id) as count_value
 from @cdm_database_schema.visit_occurrence vo1
 	inner join @cdm_database_schema.care_site cs1
 	on vo1.care_site_id = cs1.care_site_id
@@ -5219,7 +5219,7 @@ group by cs1.place_of_service_concept_id;
 -- 1202	Number of care sites by place of service
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1202 as analysis_id,  
-	cs1.place_of_service_concept_id as stratum_1, 
+	CAST(cs1.place_of_service_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
 where cs1.place_of_service_concept_id is not null
@@ -5296,7 +5296,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1406 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5368,7 +5368,7 @@ priorStats (stratum_id, count_value, total, accumulated) as
   group by s.stratum_id, s.count_value, s.total, s.rn
 )
 select 1407 as analysis_id,
-  o.stratum_id,
+  CAST(o.stratum_id AS VARCHAR(255)) AS stratum_id,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -5403,7 +5403,7 @@ drop table #tempResults;
 -- 1408	Number of persons by length of payer plan period, in 30d increments
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1408 as analysis_id,  
-	floor(DATEDIFF(dd, ppp1.payer_plan_period_start_date, ppp1.payer_plan_period_end_date)/30) as stratum_1, 
+	CAST(floor(DATEDIFF(dd, ppp1.payer_plan_period_start_date, ppp1.payer_plan_period_end_date)/30) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
 	inner join 
@@ -5415,7 +5415,7 @@ from @cdm_database_schema.PERSON p1
 	) ppp1
 	on p1.PERSON_ID = ppp1.PERSON_ID
 	where ppp1.rn1 = 1
-group by floor(DATEDIFF(dd, ppp1.payer_plan_period_start_date, ppp1.payer_plan_period_end_date)/30)
+group by CAST(floor(DATEDIFF(dd, ppp1.payer_plan_period_start_date, ppp1.payer_plan_period_end_date)/30) AS VARCHAR(255))
 ;
 --}
 
@@ -5437,7 +5437,7 @@ from
 
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1409 as analysis_id,  
-	t1.obs_year as stratum_1, COUNT_BIG(distinct p1.PERSON_ID) as count_value
+	CAST(t1.obs_year AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
 	inner join 
@@ -5475,7 +5475,7 @@ FROM
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 
   1410 as analysis_id, 
-	obs_month as stratum_1, 
+	CAST(obs_month AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
@@ -5530,7 +5530,7 @@ group by cast(cast(YEAR(payer_plan_period_end_date) as varchar(4)) +  RIGHT('0' 
 -- 1413	Number of persons by number of payer plan periods
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1413 as analysis_id,  
-	ppp1.num_periods as stratum_1, 
+	CAST(ppp1.num_periods AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
@@ -5664,7 +5664,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1502 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5730,7 +5730,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1503 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5795,7 +5795,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1504 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5860,7 +5860,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1505 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5925,7 +5925,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1506 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -5989,7 +5989,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1507 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -6054,7 +6054,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1508 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -6119,7 +6119,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1509 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6183,7 +6183,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1510 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6246,7 +6246,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1511 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6370,7 +6370,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1602 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6435,7 +6435,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1603 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6499,7 +6499,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1604 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6563,7 +6563,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1605 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6627,7 +6627,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1606 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6691,7 +6691,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1607 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6756,7 +6756,7 @@ priorStats (stratum1_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.count_value, s.total, s.rn
 )
 select 1608 as analysis_id,
-  p.stratum1_id as stratum_1,
+  CAST(p.stratum1_id AS VARCHAR(255)) as stratum_1,
   o.total as count_value,
   o.min_value,
   o.max_value,
@@ -6795,7 +6795,7 @@ drop table #tempResults;
 -- 1610	Number of records by revenue_code_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1610 as analysis_id, 
-	revenue_code_concept_id as stratum_1, 
+	CAST(revenue_code_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(pc1.procedure_cost_ID) as count_value
 from
 	@cdm_database_schema.procedure_cost pc1
@@ -6823,7 +6823,7 @@ ACHILLES Analyses on COHORT table
 -- 1700	Number of records by cohort_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1700 as analysis_id, 
-	cohort_definition_id as stratum_1, 
+	CAST(cohort_definition_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(subject_ID) as count_value
 from
 	@cdm_database_schema.cohort c1
@@ -6855,7 +6855,7 @@ ACHILLES Analyses on MEASUREMENT table
 -- 1800	Number of persons with at least one measurement occurrence, by measurement_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1800 as analysis_id, 
-	m.measurement_CONCEPT_ID as stratum_1,
+	CAST(m.measurement_CONCEPT_ID AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.measurement m
@@ -6868,7 +6868,7 @@ group by m.measurement_CONCEPT_ID
 -- 1801	Number of measurement occurrence records, by measurement_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1801 as analysis_id, 
-	m.measurement_concept_id as stratum_1,
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from
 	@cdm_database_schema.measurement m
@@ -6882,8 +6882,8 @@ group by m.measurement_CONCEPT_ID
 -- 1802	Number of persons by measurement occurrence start month, by measurement_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 1802 as analysis_id,   
-	m.measurement_concept_id as stratum_1,
-	YEAR(measurement_date)*100 + month(measurement_date) as stratum_2, 
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(measurement_date)*100 + month(measurement_date) AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(distinct PERSON_ID) as count_value
 from
 	@cdm_database_schema.measurement m
@@ -6966,10 +6966,10 @@ drop table #tempResults;
 -- 1804	Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, stratum_4, count_value)
 select 1804 as analysis_id,   
-	m.measurement_concept_id as stratum_1,
-	YEAR(measurement_date) as stratum_2,
-	p1.gender_concept_id as stratum_3,
-	floor((year(measurement_date) - p1.year_of_birth)/10) as stratum_4, 
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(YEAR(measurement_date) AS VARCHAR(255)) as stratum_2,
+	CAST(p1.gender_concept_id AS VARCHAR(255)) as stratum_3,
+	CAST(floor((year(measurement_date) - p1.year_of_birth)/10) AS VARCHAR(255)) as stratum_4,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from @cdm_database_schema.PERSON p1
 inner join @cdm_database_schema.measurement m on p1.person_id = m.person_id
@@ -6984,8 +6984,8 @@ group by m.measurement_concept_id,
 -- 1805	Number of measurement records, by measurement_concept_id by measurement_type_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 1805 as analysis_id, 
-	m.measurement_concept_id as stratum_1,
-	m.measurement_type_concept_id as stratum_2,
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(m.measurement_type_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from @cdm_database_schema.measurement m
 group by m.measurement_concept_id,	
@@ -7037,8 +7037,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1806 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -7073,8 +7073,8 @@ drop table #tempResults;
 -- 1807	Number of measurement occurrence records, by measurement_concept_id and unit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
 select 1807 as analysis_id, 
-	m.measurement_concept_id as stratum_1,
-	m.unit_concept_id as stratum_2,
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(m.unit_concept_id AS VARCHAR(255)) as stratum_2,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from @cdm_database_schema.measurement m
 group by m.measurement_concept_id, m.unit_concept_id
@@ -7184,8 +7184,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1815 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -7255,8 +7255,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1816 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -7326,8 +7326,8 @@ priorStats (stratum1_id, stratum2_id, count_value, total, accumulated) as
   group by s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
 )
 select 1817 as analysis_id,
-  o.stratum1_id,
-  o.stratum2_id,
+  CAST(o.stratum1_id AS VARCHAR(255)) AS stratum1_id,
+  CAST(o.stratum2_id AS VARCHAR(255)) AS stratum2_id,
   o.total as count_value,
   o.min_value,
 	o.max_value,
@@ -7363,12 +7363,12 @@ drop table #tempResults;
 -- 1818	Number of observation records below/within/above normal range, by observation_concept_id and unit_concept_id
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
 select 1818 as analysis_id,  
-	m.measurement_concept_id as stratum_1,
-	m.unit_concept_id as stratum_2,
-	case when m.value_as_number < m.range_low then 'Below Range Low'
+	CAST(m.measurement_concept_id AS VARCHAR(255)) as stratum_1,
+	CAST(m.unit_concept_id AS VARCHAR(255)) as stratum_2,
+	CAST(case when m.value_as_number < m.range_low then 'Below Range Low'
 		when m.value_as_number >= m.range_low and m.value_as_number <= m.range_high then 'Within Range'
 		when m.value_as_number > m.range_high then 'Above Range High'
-		else 'Other' end as stratum_3,
+		else 'Other' end AS VARCHAR(255)) as stratum_3,
 	COUNT_BIG(m.PERSON_ID) as count_value
 from @cdm_database_schema.measurement m
 where m.value_as_number is not null
@@ -7377,10 +7377,10 @@ where m.value_as_number is not null
 	and m.range_high is not null
 group by measurement_concept_id,
 	unit_concept_id,
-	  case when m.value_as_number < m.range_low then 'Below Range Low'
+	  CAST(case when m.value_as_number < m.range_low then 'Below Range Low'
 		when m.value_as_number >= m.range_low and m.value_as_number <= m.range_high then 'Within Range'
 		when m.value_as_number > m.range_high then 'Above Range High'
-		else 'Other' end
+		else 'Other' end AS VARCHAR(255))
 ;
 --}
 
@@ -7391,7 +7391,7 @@ group by measurement_concept_id,
 -- 1820	Number of observation records by condition occurrence start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1820 as analysis_id,   
-	YEAR(measurement_date)*100 + month(measurement_date) as stratum_1, 
+	CAST(YEAR(measurement_date)*100 + month(measurement_date) AS VARCHAR(255)) as stratum_1,
 	COUNT_BIG(PERSON_ID) as count_value
 from @cdm_database_schema.measurement m
 group by YEAR(measurement_date)*100 + month(measurement_date)
@@ -7422,7 +7422,7 @@ Reports
 -- 1900	concept_0 report
 
 INSERT INTO @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 1900 as analysis_id, table_name as stratum_1, source_value as stratum_2, cnt as count_value
+select 1900 as analysis_id, CAST(table_name AS VARCHAR(255)) as stratum_1, source_value as stratum_2, cnt as count_value
  from (
 select 'measurement' as table_name,measurement_source_value as source_value, COUNT_BIG(*) as cnt from @cdm_database_schema.measurement where measurement_concept_id = 0 group by measurement_source_value 
 union


### PR DESCRIPTION
This PR includes the changes I needed to run all the Achilles v5 queries on Impala. Impala is strict about types, so mostly it is adding CASTs in the right places.

Note that it relies on the Impala changes in DatabaseConnector and SqlRender, but since these have been committed they are picked up automatically.