### PR TITLE
Remove back-quoted 'location' field and handle in SqlRender

### DIFF
--- a/README-impala.md
+++ b/README-impala.md
@@ -16,6 +16,9 @@ In R, use the following commands to install the Impala development version of Ac
 install.packages("devtools")
 library(devtools)
 
+install_github("tomwhite/SqlRender", ref="impala-location-reserved-word")
+library(SqlRender)
+
 install_github("tomwhite/Achilles", ref="impala") 
 ```
 

--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -294,7 +294,7 @@ SELECT
 		location_source_value,
     row_number() over (order by location_id) rn
 FROM
-		@cdm_database_schema.`location`
+		@cdm_database_schema.location
 ) location
 WHERE rn = 1;
 
@@ -1368,7 +1368,7 @@ where p1.provider_id is not null
 insert into @results_database_schema.ACHILLES_results (analysis_id, count_value)
 select 8 as analysis_id,  COUNT_BIG(p1.person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	left join @cdm_database_schema.`location` l1
+	left join @cdm_database_schema.location l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.location_id is null
@@ -5131,7 +5131,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1100 as analysis_id,  
 	CAST(left(l1.zip,3) AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	inner join @cdm_database_schema.`location` l1
+	inner join @cdm_database_schema.LOCATION l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.zip is not null
@@ -5145,7 +5145,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1101 as analysis_id,  
 	CAST(l1.state AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct person_id) as count_value
 from @cdm_database_schema.PERSON p1
-	inner join @cdm_database_schema.`location` l1
+	inner join @cdm_database_schema.LOCATION l1
 	on p1.location_id = l1.location_id
 where p1.location_id is not null
 	and l1.state is not null
@@ -5159,7 +5159,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1102 as analysis_id,  
 	CAST(left(l1.zip,3) AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
-	inner join @cdm_database_schema.`location` l1
+	inner join @cdm_database_schema.LOCATION l1
 	on cs1.location_id = l1.location_id
 where cs1.location_id is not null
 	and l1.zip is not null
@@ -5173,7 +5173,7 @@ insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, c
 select 1103 as analysis_id,  
 	CAST(l1.state AS VARCHAR(255)) as stratum_1, COUNT_BIG(distinct care_site_id) as count_value
 from @cdm_database_schema.care_site cs1
-	inner join @cdm_database_schema.`location` l1
+	inner join @cdm_database_schema.LOCATION l1
 	on cs1.location_id = l1.location_id
 where cs1.location_id is not null
 	and l1.state is not null


### PR DESCRIPTION
This reverts the change to quote the 'location' table, and handles it in the Impala dialect of SqlRender, see https://github.com/OHDSI/SqlRender/compare/master...tomwhite:impala-location-reserved-word.

I have successfully tested this change on all the Achilles tables.