### PR TITLE
Remove mssql filter from testthat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ before_install:
   - Rscript -e 'update.packages(ask = FALSE)'
   - export LD_LIBRARY_PATH=$JAVA_HOME:$LD_LIBRARY_PATH
 
+script: 
+  - |
+    R CMD build .
+    travis_wait 30 R CMD check Achilles*tar.gz
+    
 notifications:
   recipients:
     - cknoll1@its.jnj.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ after_success:
   # Rebuild drat repo
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
 
+after_failure:
+- find *Rcheck -name '*.fail' -print -exec cat '{}' \;
+
 env:
   global:
     secure: a1Rdhif0jhUZRpNqLzIYbEBCM/+VbbTJhT3/vfxZKy+PiLVQixi/ARqvA581p/JRfsA3d9koWynxy6+karOKw94b27+Uaos8ds85noObq3enND+d/FNVqDA9mn9l0tDFioeKR7T2SQlyWF1LIWtKzj9L21/EjNSy8mi0btiiJaU=

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(Achilles)
 
-test_check("Achilles", filter="_mssql$")
+test_check("Achilles")


### PR DESCRIPTION
This is to remove the filter from the test_check to only look at mssql tests.  This will verify if the TravisCI will execute without timeout across all dbms.
