### PR TITLE
Fixes for Postgresql and Oracle

### DIFF
--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -1839,8 +1839,8 @@ IF OBJECT_ID('tempdb..#temp_dates', 'U') IS NOT NULL
 
 SELECT DISTINCT 
   YEAR(observation_period_start_date) AS obs_year,
-  CAST(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), '01', '01') AS DATE) AS obs_year_start,
-  CAST(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), '12', '31') AS DATE) AS obs_year_end
+  CAST(CONCAT(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), '01'), '01') AS DATE) AS obs_year_start,
+  CAST(CONCAT(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), '12'), '31') AS DATE) AS obs_year_end
 INTO
   #temp_dates
 FROM @cdm_database_schema.observation_period
@@ -1854,9 +1854,9 @@ SELECT
 FROM @cdm_database_schema.observation_period,
 	#temp_dates
 WHERE  
-		CAST(observation_period_start_date AS DATE) <= obs_year_start
+		observation_period_start_date <= obs_year_start
 	AND 
-		CAST(observation_period_end_date AS DATE) >= obs_year_end
+		observation_period_end_date >= obs_year_end
 GROUP BY 
 	obs_year
 ;
@@ -1875,9 +1875,9 @@ IF OBJECT_ID('tempdb..#temp_dates', 'U') IS NOT NULL
 
 SELECT DISTINCT 
   YEAR(observation_period_start_date)*100 + MONTH(observation_period_start_date) AS obs_month,
-  CAST(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), RIGHT(CONCAT('0', CAST(MONTH(OBSERVATION_PERIOD_START_DATE) AS VARCHAR(2))), 2), '01') AS DATE)
+  CAST(CONCAT(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), RIGHT(CONCAT('0', CAST(MONTH(OBSERVATION_PERIOD_START_DATE) AS VARCHAR(2))), 2)), '01') AS DATE)
   AS obs_month_start,
-  DATEADD(dd,-1,DATEADD(mm,1,CAST(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), RIGHT(CONCAT('0', CAST(MONTH(OBSERVATION_PERIOD_START_DATE) AS VARCHAR(2))), 2), '01') AS DATE))) AS obs_month_end
+  DATEADD(dd,-1,DATEADD(mm,1,CAST(CONCAT(CONCAT(CAST(YEAR(observation_period_start_date) AS VARCHAR(4)), RIGHT(CONCAT('0', CAST(MONTH(OBSERVATION_PERIOD_START_DATE) AS VARCHAR(2))), 2)), '01') AS DATE))) AS obs_month_end
 INTO
   #temp_dates
 FROM @cdm_database_schema.observation_period
@@ -1893,9 +1893,9 @@ FROM
 	@cdm_database_schema.observation_period,
 	#temp_Dates
 WHERE 
-		CAST(observation_period_start_date AS DATE) <= obs_month_start
+		observation_period_start_date <= obs_month_start
 	AND
-		CAST(observation_period_end_date AS DATE) >= obs_month_end
+		observation_period_end_date >= obs_month_end
 GROUP BY 
 	obs_month
 ;
@@ -5530,13 +5530,13 @@ DROP TABLE #temp_dates;
 -- 1411	Number of persons by payer plan period start month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1411 as analysis_id, 
-	cast(CONCAT(cast(YEAR(payer_plan_period_start_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_START_DATE) AS VARCHAR(2))), 2), '01')) as VARCHAR(255)) as stratum_1,
+	cast(CONCAT(CONCAT((cast(YEAR(payer_plan_period_start_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_START_DATE) AS VARCHAR(2))), 2)), '01')) as VARCHAR(255)) as stratum_1,
 	 COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
 	inner join @cdm_database_schema.payer_plan_period ppp1
 	on p1.person_id = ppp1.person_id
-group by cast(CONCAT(cast(YEAR(payer_plan_period_start_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_START_DATE) AS VARCHAR(2))), 2), '01')) as VARCHAR(255))
+group by cast(CONCAT(CONCAT(cast(YEAR(payer_plan_period_start_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_START_DATE) AS VARCHAR(2))), 2)), '01')) as VARCHAR(255))
 ;
 --}
 
@@ -5546,13 +5546,13 @@ group by cast(CONCAT(cast(YEAR(payer_plan_period_start_date) as varchar(4)), CON
 -- 1412	Number of persons by payer plan period end month
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, count_value)
 select 1412 as analysis_id,  
-	cast(CONCAT(cast(YEAR(payer_plan_period_end_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_end_DATE) AS VARCHAR(2))), 2), '01')) as VARCHAR(255)) as stratum_1,
+	cast(CONCAT(CONCAT(cast(YEAR(payer_plan_period_end_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_end_DATE) AS VARCHAR(2))), 2)), '01')) as VARCHAR(255)) as stratum_1,
 	COUNT_BIG(distinct p1.PERSON_ID) as count_value
 from
 	@cdm_database_schema.PERSON p1
 	inner join @cdm_database_schema.payer_plan_period ppp1
 	on p1.person_id = ppp1.person_id
-group by cast(CONCAT(cast(YEAR(payer_plan_period_end_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_end_DATE) AS VARCHAR(2))), 2), '01')) as VARCHAR(255))
+group by cast(CONCAT(CONCAT(cast(YEAR(payer_plan_period_end_date) as varchar(4)), CONCAT(RIGHT(CONCAT('0', CAST(month(payer_plan_period_end_DATE) AS VARCHAR(2))), 2)), '01')) as VARCHAR(255))
 ;
 --}
 


### PR DESCRIPTION
Changed CONCAT functions to only take 2 parameters by nesting those CONCAT calls that have > 2 params together.
Fixes #191

Removed casting from DATE to DATE in analysis 109.  
Fixes #187