### PR TITLE
Fixes logic for handling if CDM_DOMAIN_META table is not present.

### DIFF
--- a/R/exportToJson.R
+++ b/R/exportToJson.R
@@ -616,22 +616,18 @@ generateDomainMetaReport <- function(conn, dbms, cdmDatabaseSchema, resultsDatab
   queryDomainMeta <- loadRenderTranslateSql(sqlFilename = addCdmVersionPath("/domainmeta/sqlDomainMeta.sql",cdmVersion),
                                             packageName = "Achilles",
                                             dbms = dbms,
-                                            cdm_database_schema = cdmDatabaseSchema,
-                                            results_database_schema = resultsDatabaseSchema,
-                                            vocab_database_schema = vocabDatabaseSchema
+                                            cdm_database_schema = cdmDatabaseSchema
   )  
   
-  try(
-    output$MESSAGES <- querySql(conn,queryDomainMeta)
-  )
-  if (is.null(output$MESSAGES))
+  if ("CDM_DOMAIN_META" %in% DatabaseConnector::getTableNames(connection = conn, databaseSchema = cdmDatabaseSchema))
   {
-    writeLines("No CDM_DOMAIN_META table found, skipping export")
+    output$MESSAGES <- querySql(conn, queryDomainMeta) 
+    jsonOutput = toJSON(output)
+    write(jsonOutput, file=paste(outputPath, "/domainmeta.json", sep=""))  
   }
   else
   {
-    jsonOutput = toJSON(output)
-    write(jsonOutput, file=paste(outputPath, "/domainmeta.json", sep=""))  
+    writeLines("No CDM_DOMAIN_META table found, skipping export")  
   }
 }
 

--- a/inst/sql/sql_server/export_v5/domainmeta/sqlDomainMeta.sql
+++ b/inst/sql/sql_server/export_v5/domainmeta/sqlDomainMeta.sql
@@ -1,4 +1,4 @@
 select domain_id as AttributeName, description as AttributeValue
-from @results_database_schema.cdm_domain_meta
+from @cdm_database_schema.cdm_domain_meta
 where description is not null
 order by domain_id


### PR DESCRIPTION
Uses DatabaseConnector's getTableNames function to grab available tables to check if CDM_DOMAIN_META is present. Earlier logic was misusing R's try function. 