### PR TITLE
forcibly change NLS_DATE_FORMAT to 'YYYYMMDD' for oracle flavors

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -136,6 +136,11 @@ achilles <- function (connectionDetails,
   } else {
     conn <- DatabaseConnector::connect(connectionDetails)
     writeLines("Executing multiple queries. This could take a while")
+    if( connectionDetails$dbms == "oracle" ){
+        writeLines( "Setting NLS_DATE_FORMAT for this session" )
+        DatabaseConnector::executeSql( conn ,
+                                      'alter session set NLS_DATE_FORMAT="YYYYMMDD"' )
+    }
     #SqlRender::writeSql(achillesSql, 'achillesDebug.sql');
     DatabaseConnector::executeSql(conn,achillesSql)
     writeLines(paste("Done. Achilles results can now be found in",resultsDatabaseSchema))


### PR DESCRIPTION
Fixes https://github.com/OHDSI/Achilles/issues/225

RStudio complained about 'java.sql.SQLDataException: ORA-01861:
literal does not match format string' and could only get 44%
through the initial Achilles run.

The underlying problem was tied to the use of CAST on an Oracle
datefield in the SQL command shown in the errorReport.txt file.
CASE is good because it is ANSI standard sql but it presupposes
the date format is 'YYYYMMDD'.