### PR TITLE
Conditionally applying a clustered columnstore index for pdw

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -347,6 +347,7 @@ conceptHierarchy <- function (connectionDetails,
 createIndices <- function (connectionDetails, 
                            resultsDatabaseSchema,
                            oracleTempSchema = resultsDatabaseSchema,
+                           sqlOnly = FALSE,
                            cdmVersion = "5"){
   
   if (cdmVersion == "5") {
@@ -359,15 +360,21 @@ createIndices <- function (connectionDetails,
     stop("Error: RedShift does not support creating indices")
   }
   
+  is_pdw <- (connectionDetails$dbms == "pdw")
+  
   indicesSql <- SqlRender::loadRenderTranslateSql(sqlFilename = sqlFile,
                                          packageName = "Achilles",
                                          dbms = connectionDetails$dbms,
                                          oracleTempSchema = oracleTempSchema,
+                                         is_pdw = is_pdw,
                                          results_database_schema = resultsDatabaseSchema);
   
-  conn <- DatabaseConnector::connect(connectionDetails);
-  writeLines("Executing indices creation. This could take a while")
-  DatabaseConnector::executeSql(conn,indicesSql)
-  writeLines(paste("Done. Indices created in",resultsDatabaseSchema))  
+  if (!sqlOnly) {
+    conn <- DatabaseConnector::connect(connectionDetails);
+    writeLines("Executing indices creation. This could take a while")
+    DatabaseConnector::executeSql(conn,indicesSql)
+    writeLines(paste("Done. Indices created in",resultsDatabaseSchema))  
+  }
   return(indicesSql)
 }
+

--- a/inst/sql/sql_server/Achilles_indices_v5.sql
+++ b/inst/sql/sql_server/Achilles_indices_v5.sql
@@ -27,10 +27,18 @@
 Achilles - indices for tables
 
 *******************************************************************/
+{DEFAULT @is_pdw = FALSE}
 
 /**************************************************/
 /***** Add indexes to Achilles results tables *****/
 /**************************************************/
+
+
+{@is_pdw}?{
+CREATE CLUSTERED COLUMNSTORE INDEX ClusteredIndex_Achilles_results 
+  ON @results_database_schema.ACHILLES_results;
+}
+
 CREATE INDEX idx_ar_aid
   ON @results_database_schema.ACHILLES_results (analysis_id);
 CREATE INDEX idx_ar_s1


### PR DESCRIPTION
Conditionally adding a clustered columnstore index to ACHILLES_results when the DBMS is Microsoft APS (aka PDW). Without this index, we were finding that queries that attempted to CAST(stratum_1, int) would fail which was causing problems upstream with WebAPI.

If approved, it would be great if this could be a v1.5.1 release of Achilles to include this fix. Thanks!