### PR TITLE
updated dockerfile for solving dependency problem with dplyr and Para…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ RUN echo 'options(repos=structure(c(CRAN="http://cran.cnr.berkeley.edu/")))' > /
       OHDSI/DatabaseConnector \
       OHDSI/OhdsiRTools \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+RUN R -e "install.packages(c('devtools','dplyr'))"
+RUN R -e "devtools::install_github('ohdsi/ParallelLogger')"
 
 # Configure workspace
 WORKDIR /opt/app


### PR DESCRIPTION
This addition to the DockerFile (installation of dplyr and ParallelLogger packages) solves the problem:

```
* installing to library ‘/usr/local/lib/R/site-library’
ERROR: dependencies ‘dplyr’, ‘ParallelLogger’ are not available for package ‘Achilles’
* removing ‘/usr/local/lib/R/site-library/Achilles’
ERROR: Service 'achilles' failed to build: The command '/bin/sh -c R CMD INSTALL /opt/app     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds     && find /opt/app -mindepth 1 -not \( -wholename /opt/app/docker-run -or -wholename /opt/app/output \) -delete' returned a non-zero code: 1
```

(installation of devtools package is required for downloading the latest version of ParallelLogger) 