### PR TITLE
Swapped static "secs" for time units calculation

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -495,7 +495,7 @@ achilles <- function (connectionDetails,
         tryCatch({
           DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
           delta = Sys.time() - start
-          ParallelLogger::logInfo(sprintf("Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta,"units")))  
+          ParallelLogger::logInfo(sprintf("Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta, "units")))  
         }, error = function(e) {
           ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
         })
@@ -512,7 +512,7 @@ achilles <- function (connectionDetails,
                                            tryCatch({
                                              DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
                                              delta = Sys.time() - start
-                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta,"units")))  
+                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta, "units")))  
                                            }, error = function(e) {
                                              ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
                                            }, finally = function(f) {

--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -494,7 +494,7 @@ achilles <- function (connectionDetails,
                                         analysisDetails$ANALYSIS_NAME[analysisDetails$ANALYSIS_ID == mainSql$analysisId]))
         tryCatch({
           DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
-          delta = Sys.time() - start
+          delta <- Sys.time() - start
           ParallelLogger::logInfo(sprintf("Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta, "units")))  
         }, error = function(e) {
           ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
@@ -511,7 +511,7 @@ achilles <- function (connectionDetails,
                                                                            analysisDetails$ANALYSIS_NAME[analysisDetails$ANALYSIS_ID == mainSql$analysisId]))
                                            tryCatch({
                                              DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
-                                             delta = Sys.time() - start
+                                             delta <- Sys.time() - start
                                              ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta, "units")))  
                                            }, error = function(e) {
                                              ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))

--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -494,7 +494,8 @@ achilles <- function (connectionDetails,
                                         analysisDetails$ANALYSIS_NAME[analysisDetails$ANALYSIS_ID == mainSql$analysisId]))
         tryCatch({
           DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
-          ParallelLogger::logInfo(sprintf("Analysis %d -- COMPLETE (%f secs)", mainSql$analysisId, Sys.time() - start))  
+          delta = Sys.time() - start
+          ParallelLogger::logInfo(sprintf("Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta,"units")))  
         }, error = function(e) {
           ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
         })
@@ -510,7 +511,8 @@ achilles <- function (connectionDetails,
                                                                            analysisDetails$ANALYSIS_NAME[analysisDetails$ANALYSIS_ID == mainSql$analysisId]))
                                            tryCatch({
                                              DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
-                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f secs)", mainSql$analysisId, Sys.time() - start))  
+                                             delta = Sys.time() - start
+                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, attr(delta,"units")))  
                                            }, error = function(e) {
                                              ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
                                            }, finally = function(f) {

--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -512,7 +512,7 @@ achilles <- function (connectionDetails,
                                            tryCatch({
                                              DatabaseConnector::executeSql(connection = connection, sql = mainSql$sql)
                                              delta = Sys.time() - start
-                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, attr(delta,"units")))  
+                                             ParallelLogger::logInfo(sprintf("Main Analysis %d -- COMPLETE (%f %s)", mainSql$analysisId, delta, attr(delta,"units")))  
                                            }, error = function(e) {
                                              ParallelLogger::logError(sprintf("Analysis %d -- ERROR %s", mainSql$analysisId, e))
                                            }, finally = function(f) {

--- a/R/exportToJson.R
+++ b/R/exportToJson.R
@@ -194,7 +194,7 @@ exportToJson <- function (connectionDetails,
   }
   
   delta <- Sys.time() - start
-  writeLines(paste("Export took", signif(delta,3), attr(delta,"units")))
+  writeLines(paste("Export took", signif(delta,3), attr(delta, "units")))
   writeLines(paste("JSON files can now be found in",outputPath))
 }
 


### PR DESCRIPTION
Achilles.R was displaying all run durations as seconds, regardless of if the value represented minutes (or otherwise). Modified it to show the correct units in a similar fashion to R/exportToJson.R