### PR TITLE
Fixes for distributed cost SQL and errors at execution end

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -653,10 +653,6 @@ achilles <- function (connectionDetails,
     ParallelLogger::logInfo(sprintf("All Achilles SQL scripts can be found in folder: %s", file.path(outputFolder, "achilles.sql")))
   }
 
-  if (exists('connection')) {
-    DatabaseConnector::disconnect(connection = connection)
-  }
-  
   achillesResults <- list(resultsConnectionDetails = connectionDetails,
                           resultsTable = "achilles_results",
                           resultsDistributionTable = "achilles_results_dist",

--- a/R/AchillesHeel.R
+++ b/R/AchillesHeel.R
@@ -327,9 +327,9 @@ achillesHeel <- function(connectionDetails,
     
     if (i > 1) {
       sqlDropPriors <- lapply(drops, function(drop) {
-        sql <- SqlRender::renderSql(sql = "IF OBJECT_ID('tempdb..#@table', 'U') IS NOT NULL DROP TABLE #@table;",
-                             table = sprintf("serial_%2s", drop))$sql
-        sql <- SqlRender::translateSql(sql = sql, targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)$sql
+        sql <- SqlRender::render(sql = "IF OBJECT_ID('tempdb..#@table', 'U') IS NOT NULL DROP TABLE #@table;",
+                             table = sprintf("serial_%2s", drop))
+        sql <- SqlRender::translate(sql = sql, targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)
       }) 
       sqlDropPrior <- paste(sqlDropPriors, collapse = "\n\n")
     }
@@ -355,9 +355,9 @@ achillesHeel <- function(connectionDetails,
                                              schema = resultsDatabaseSchema,
                                              schemaDelim = ".",
                                              destination = "achilles_results_derived",
-                                             derivedSqls = SqlRender::translateSql(
+                                             derivedSqls = SqlRender::translate(
                                                 sql = sprintf("select * from #serial_rd_%d", rdId),
-                                                targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)$sql
+                                                targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)
                                              )
   
   sqlHr <- SqlRender::loadRenderTranslateSql(sqlFilename = "heels/merge_heel_results.sql", 
@@ -367,9 +367,9 @@ achillesHeel <- function(connectionDetails,
                                              schema = resultsDatabaseSchema,
                                              schemaDelim = ".",
                                              destination = "achilles_heel_results",
-                                             resultSqls = SqlRender::translateSql(
+                                             resultSqls = SqlRender::translate(
                                                 sql = sprintf("select * from #serial_hr_%d", hrId),
-                                                targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)$sql
+                                                targetDialect = connectionDetails$dbms, oracleTempSchema = scratchDatabaseSchema)
                                              )
   
   finalSqls <- c(sqlRd, sqlHr)

--- a/R/AchillesHeel.R
+++ b/R/AchillesHeel.R
@@ -411,10 +411,6 @@ achillesHeel <- function(connectionDetails,
   
   ParallelLogger::unregisterLogger("achillesHeel")
 
-  if (exists('connection')) {
-    DatabaseConnector::disconnect(connection = connection)
-  }
-  
   heelResults <- list(resultsConnectionDetails = connectionDetails,
                       resultsTable = "achilles_heel_results",
                       heelSql = paste(heelSql, collapse = "\n\n"),

--- a/inst/sql/sql_server/analyses/1002.sql
+++ b/inst/sql/sql_server/analyses/1002.sql
@@ -1,7 +1,7 @@
 -- 1002	Number of persons by condition occurrence start month, by condition_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     ce1.condition_concept_id as stratum_1,
     YEAR(condition_era_start_date)*100 + month(condition_era_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1002
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1004.sql
+++ b/inst/sql/sql_server/analyses/1004.sql
@@ -1,7 +1,7 @@
 -- 1004	Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     ce1.condition_concept_id as stratum_1,
     YEAR(condition_era_start_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1004
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/101.sql
+++ b/inst/sql/sql_server/analyses/101.sql
@@ -1,7 +1,7 @@
 -- 101	Number of persons by age, with age at first observation period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     year(op1.index_date) - p1.YEAR_OF_BIRTH as stratum_1,
     COUNT_BIG(p1.person_id) as count_value
@@ -19,4 +19,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 INTO @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_101
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/102.sql
+++ b/inst/sql/sql_server/analyses/102.sql
@@ -1,7 +1,7 @@
 -- 102	Number of persons by gender by age, with age at first observation period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     p1.gender_concept_id as stratum_1,
     year(op1.index_date) - p1.YEAR_OF_BIRTH as stratum_2,
@@ -19,4 +19,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_102
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1020.sql
+++ b/inst/sql/sql_server/analyses/1020.sql
@@ -1,7 +1,7 @@
 -- 1020	Number of drug era records by drug era start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(condition_era_start_date)*100 + month(condition_era_start_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1020
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/108.sql
+++ b/inst/sql/sql_server/analyses/108.sql
@@ -1,7 +1,7 @@
 -- 108	Number of persons by length of observation period, in 30d increments
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     floor(DATEDIFF(dd, op1.observation_period_start_date, op1.observation_period_end_date)/30) as stratum_1,
     COUNT_BIG(distinct p1.person_id) as count_value
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_108
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1100.sql
+++ b/inst/sql/sql_server/analyses/1100.sql
@@ -1,7 +1,7 @@
 -- 1100	Number of persons by location 3-digit zip
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     left(l1.zip,3) as stratum_1,
     COUNT_BIG(distinct person_id) as count_value
@@ -21,4 +21,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1100
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1102.sql
+++ b/inst/sql/sql_server/analyses/1102.sql
@@ -1,7 +1,7 @@
 -- 1102	Number of care sites by location 3-digit zip
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     left(l1.zip,3) as stratum_1,
     COUNT_BIG(distinct care_site_id) as count_value
@@ -21,4 +21,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1102
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/111.sql
+++ b/inst/sql/sql_server/analyses/111.sql
@@ -1,7 +1,7 @@
 -- 111	Number of persons by observation period start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(observation_period_start_date)*100 + month(OBSERVATION_PERIOD_START_DATE) as stratum_1,
     COUNT_BIG(distinct op1.PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_111
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/112.sql
+++ b/inst/sql/sql_server/analyses/112.sql
@@ -1,7 +1,7 @@
 -- 112	Number of persons by observation period end month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(observation_period_end_date)*100 + month(observation_period_end_date) as stratum_1,
     COUNT_BIG(distinct op1.PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_112
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/116.sql
+++ b/inst/sql/sql_server/analyses/116.sql
@@ -12,7 +12,7 @@ from
 ;
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     t1.obs_year as stratum_1,
     p1.gender_concept_id as stratum_2,
@@ -40,7 +40,7 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_116
-FROM raw;
+FROM rawData;
 
 TRUNCATE TABLE #temp_dates_116;
 DROP TABLE #temp_dates_116;

--- a/inst/sql/sql_server/analyses/1802.sql
+++ b/inst/sql/sql_server/analyses/1802.sql
@@ -1,7 +1,7 @@
 -- 1802	Number of persons by measurement occurrence start month, by measurement_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     m.measurement_concept_id as stratum_1,
     YEAR(measurement_date)*100 + month(measurement_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1802
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1804.sql
+++ b/inst/sql/sql_server/analyses/1804.sql
@@ -1,7 +1,7 @@
 -- 1804	Number of persons with at least one measurement occurrence, by measurement_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     m.measurement_concept_id as stratum_1,
     YEAR(measurement_date) as stratum_2,
@@ -24,4 +24,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1804
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/1820.sql
+++ b/inst/sql/sql_server/analyses/1820.sql
@@ -1,7 +1,7 @@
 -- 1820	Number of observation records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(measurement_date)*100 + month(measurement_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -17,4 +17,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1820
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/202.sql
+++ b/inst/sql/sql_server/analyses/202.sql
@@ -1,7 +1,7 @@
 -- 202	Number of persons by visit occurrence start month, by visit_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     vo1.visit_concept_id as stratum_1,
     YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_202
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/204.sql
+++ b/inst/sql/sql_server/analyses/204.sql
@@ -1,7 +1,7 @@
 -- 204	Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     vo1.visit_concept_id as stratum_1,
     YEAR(visit_start_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_204
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/2102.sql
+++ b/inst/sql/sql_server/analyses/2102.sql
@@ -1,7 +1,7 @@
 -- 2102	Number of persons by device by  start month, by device_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     m.device_CONCEPT_ID as stratum_1,
     YEAR(device_exposure_start_date)*100 + month(device_exposure_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2102
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/2104.sql
+++ b/inst/sql/sql_server/analyses/2104.sql
@@ -1,7 +1,7 @@
 -- 2104	Number of persons with at least one device occurrence, by device_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     m.device_CONCEPT_ID as stratum_1,
     YEAR(device_exposure_start_date) as stratum_2,
@@ -24,4 +24,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2104
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/212.sql
+++ b/inst/sql/sql_server/analyses/212.sql
@@ -1,7 +1,7 @@
 -- 212	Number of persons with at least one visit occurrence by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(visit_start_date) as stratum_1,
     p1.gender_concept_id as stratum_2,
@@ -25,4 +25,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_212
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/220.sql
+++ b/inst/sql/sql_server/analyses/220.sql
@@ -1,7 +1,7 @@
 -- 220	Number of visit occurrence records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_220
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/221.sql
+++ b/inst/sql/sql_server/analyses/221.sql
@@ -1,7 +1,7 @@
 -- 221	Number of persons by visit start year 
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(visit_start_date) as stratum_1,
     COUNT_BIG(distinct PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_221
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/402.sql
+++ b/inst/sql/sql_server/analyses/402.sql
@@ -1,7 +1,7 @@
 -- 402	Number of persons by condition occurrence start month, by condition_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     co1.condition_concept_id as stratum_1,
     YEAR(condition_start_date)*100 + month(condition_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_402
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/404.sql
+++ b/inst/sql/sql_server/analyses/404.sql
@@ -1,7 +1,7 @@
 -- 404	Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     co1.condition_concept_id as stratum_1,
     YEAR(condition_start_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_404
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/420.sql
+++ b/inst/sql/sql_server/analyses/420.sql
@@ -1,7 +1,7 @@
 -- 420	Number of condition occurrence records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(condition_start_date)*100 + month(condition_start_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_420
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/502.sql
+++ b/inst/sql/sql_server/analyses/502.sql
@@ -1,7 +1,7 @@
 -- 502	Number of persons by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(death_date)*100 + month(death_date) as stratum_1,
     COUNT_BIG(distinct PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_502
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/504.sql
+++ b/inst/sql/sql_server/analyses/504.sql
@@ -1,7 +1,7 @@
 -- 504	Number of persons with a death, by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(death_date) as stratum_1,
     p1.gender_concept_id as stratum_2,
@@ -24,4 +24,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_504
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/602.sql
+++ b/inst/sql/sql_server/analyses/602.sql
@@ -1,7 +1,7 @@
 -- 602	Number of persons by procedure occurrence start month, by procedure_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     po1.procedure_concept_id as stratum_1,
     YEAR(procedure_date)*100 + month(procedure_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_602
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/604.sql
+++ b/inst/sql/sql_server/analyses/604.sql
@@ -1,7 +1,7 @@
 -- 604	Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     po1.procedure_concept_id as stratum_1,
     YEAR(procedure_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_604
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/620.sql
+++ b/inst/sql/sql_server/analyses/620.sql
@@ -1,7 +1,7 @@
 -- 620	Number of procedure occurrence records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(procedure_date)*100 + month(procedure_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_620
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/702.sql
+++ b/inst/sql/sql_server/analyses/702.sql
@@ -1,7 +1,7 @@
 -- 702	Number of persons by drug occurrence start month, by drug_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     de1.drug_concept_id as stratum_1,
     YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_702
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/704.sql
+++ b/inst/sql/sql_server/analyses/704.sql
@@ -1,7 +1,7 @@
 -- 704	Number of persons with at least one drug occurrence, by drug_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     de1.drug_concept_id as stratum_1,
     YEAR(drug_exposure_start_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_704
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/720.sql
+++ b/inst/sql/sql_server/analyses/720.sql
@@ -1,7 +1,7 @@
 -- 720	Number of drug exposure records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_720
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/802.sql
+++ b/inst/sql/sql_server/analyses/802.sql
@@ -1,7 +1,7 @@
 -- 802	Number of persons by observation occurrence start month, by observation_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     CAST(o1.observation_concept_id AS VARCHAR(255)) as stratum_1,
     YEAR(observation_date)*100 + month(observation_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_802
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/804.sql
+++ b/inst/sql/sql_server/analyses/804.sql
@@ -1,7 +1,7 @@
 -- 804	Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     o1.observation_concept_id as stratum_1,
     YEAR(observation_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_804
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/820.sql
+++ b/inst/sql/sql_server/analyses/820.sql
@@ -1,7 +1,7 @@
 -- 820	Number of observation records by condition occurrence start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(observation_date)*100 + month(observation_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_820
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/902.sql
+++ b/inst/sql/sql_server/analyses/902.sql
@@ -1,7 +1,7 @@
 -- 902	Number of persons by drug occurrence start month, by drug_concept_id
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     de1.drug_concept_id as stratum_1,
     YEAR(drug_era_start_date)*100 + month(drug_era_start_date) as stratum_2,
@@ -20,4 +20,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_902
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/904.sql
+++ b/inst/sql/sql_server/analyses/904.sql
@@ -1,7 +1,7 @@
 -- 904	Number of persons with at least one drug occurrence, by drug_concept_id by calendar year by gender by age decile
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     de1.drug_concept_id as stratum_1,
     YEAR(drug_era_start_date) as stratum_2,
@@ -26,4 +26,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_904
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/920.sql
+++ b/inst/sql/sql_server/analyses/920.sql
@@ -1,7 +1,7 @@
 -- 920	Number of drug era records by drug era start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-WITH raw AS (
+WITH rawData AS (
   select
     YEAR(drug_era_start_date)*100 + month(drug_era_start_date) as stratum_1,
     COUNT_BIG(PERSON_ID) as count_value
@@ -18,4 +18,4 @@ SELECT
   cast(null as varchar(255)) as stratum_5,
   count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_920
-FROM raw;
+FROM rawData;

--- a/inst/sql/sql_server/analyses/cost_distribution_template.sql
+++ b/inst/sql/sql_server/analyses/cost_distribution_template.sql
@@ -1,4 +1,6 @@
 
+-- overallStats
+
 --HINT DISTRIBUTE_ON_KEY(stratum1_id)
 select 
   subject_id as stratum1_id, 
@@ -6,14 +8,27 @@ select
   CAST(stdev(@costColumn) AS FLOAT) as stdev_value,
   min(@costColumn) as min_value,
   max(@costColumn) as max_value,
-  @costColumn as count_value,
-  count_big(*) as total,
-  row_number() over (partition by subject_id order by @costColumn) as rn
+  count_big(*) as total
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId
 from @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_@domainId_cost_raw
 where @costColumn is not null
+group by subject_id
+;
+
+-- statsView
+
+--HINT DISTRIBUTE_ON_KEY(stratum1_id)
+select
+  subject_id as stratum1_id, 
+	@costColumn as count_value, 
+  count_big(*) as total, 
+	row_number() over (partition by subject_id order by @costColumn) as rn
+into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_statsView_@analysisId
+from @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_@domainId_cost_raw
 group by subject_id, @costColumn
 ;
+
+-- priorStats
 
 --HINT DISTRIBUTE_ON_KEY(stratum1_id)
 select 
@@ -22,8 +37,8 @@ select
   s.total, 
   sum(p.total) as accumulated
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_priorStats_@analysisId
-from @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId s 
-join @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId p
+from @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_statsView_@analysisId s 
+join @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_statsView_@analysisId p
   on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
 group by s.stratum1_id, s.count_value, s.total, s.rn
 ;
@@ -41,11 +56,11 @@ select
 	o.max_value,
 	o.avg_value,
 	o.stdev_value,
-	MIN(case when p.accumulated >= .50 * o.total then o.total else o.max_value end) as median_value,
-	MIN(case when p.accumulated >= .10 * o.total then o.total else o.max_value end) as p10_value,
-	MIN(case when p.accumulated >= .25 * o.total then o.total else o.max_value end) as p25_value,
-	MIN(case when p.accumulated >= .75 * o.total then o.total else o.max_value end) as p75_value,
-	MIN(case when p.accumulated >= .90 * o.total then o.total else o.max_value end) as p90_value
+	MIN(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value,
+	MIN(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value,
+	MIN(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value,
+	MIN(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value,
+	MIN(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_dist_@analysisId
 from @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_priorStats_@analysisId p 
 join @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId o on p.stratum1_id = o.stratum1_id
@@ -54,6 +69,9 @@ group by p.stratum1_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_
 
 truncate table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId;
 drop table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_overallStats_@analysisId;
+
+truncate table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_statsView_@analysisId;
+drop table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_statsView_@analysisId;
 
 truncate table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_priorStats_@analysisId;
 drop table @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_priorStats_@analysisId;


### PR DESCRIPTION
Fixes for #374 #370 

1. The cost_distribution_template was not correctly obtaining descriptive stats by patient by cost column, it was grabbing these and grouping by the cost values.
2. The exists("connection") logic added recently does work, as it does not accurately determine if a connection is active, just that a variable named connection is in the environment. THis was throwing the error "Error: host must be a single element of type 'character'"

@t-abdul-basser  -- I think in this PR, there may be a commit that you already merged:
**Fixed a few instances of deprecated renderSql and translateSql (de835df)**, no need to re-merge this.