### PR TITLE
bug fix - capitalization typo 'sqlFileName'

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -266,7 +266,7 @@ achilles <- function (connectionDetails,
       sqlFileName <- file.path("analyses_v6", "create_analysis_table.sql")
     }
     
-    sql <- SqlRender::loadRenderTranslateSql(sqlFilename = sqlFilename, 
+    sql <- SqlRender::loadRenderTranslateSql(sqlFilename = sqlFileName, 
                                              packageName = "Achilles", 
                                              dbms = connectionDetails$dbms,
                                              warnOnMissingParameters = FALSE,


### PR DESCRIPTION
without fix, code throws error "object 'sqlFilename' not found" because the object is actually named 'sqlFileName' with a capital N