### PR TITLE
Exclude impala from supported temp tables DBs

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -1162,7 +1162,7 @@ dropAllScratchTables <- function(connectionDetails,
 }
 
 .supportsTempTables <- function(connectionDetails) {
-    !(connectionDetails$dbms %in% c("bigquery"))
+    !(connectionDetails$dbms %in% c("bigquery", "impala"))
 }
 
 .getAnalysisSql <- function(analysisId, 


### PR DESCRIPTION
Exclude impala from supported temp tables DBs.
Closes #413 