### PR TITLE
Restricting to observation period

### DIFF
--- a/inst/sql/sql_server/analyses/1003.sql
+++ b/inst/sql/sql_server/analyses/1003.sql
@@ -4,7 +4,11 @@
 with rawData(count_value) as
 (
   select COUNT_BIG(distinct ce1.condition_concept_id) as count_value
-	from @cdmDatabaseSchema.condition_era ce1
+	from @cdmDatabaseSchema.condition_era ce1 inner join 
+  @cdmDatabaseSchema.observation_period op on ce1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where ce1.condition_era_start_date <= op.observation_period_end_date and
+  isnull(ce1.condition_era_end_date,ce1.condition_era_start_date) >= op.observation_period_start_date
 	group by ce1.person_id
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as

--- a/inst/sql/sql_server/analyses/1020.sql
+++ b/inst/sql/sql_server/analyses/1020.sql
@@ -1,13 +1,18 @@
--- 1020	Number of drug era records by drug era start month
+-- 1020	Number of condition era records by condition era start month
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(condition_era_start_date)*100 + month(condition_era_start_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(ce1.condition_era_start_date)*100 + month(ce1.condition_era_start_date) as stratum_1,
+    COUNT_BIG(ce1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.condition_era ce1
-  group by YEAR(condition_era_start_date)*100 + month(condition_era_start_date)
+  @cdmDatabaseSchema.condition_era ce1 inner join 
+  @cdmDatabaseSchema.observation_period op on ce1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where ce1.condition_era_start_date <= op.observation_period_end_date and
+  isnull(ce1.condition_era_end_date,ce1.condition_era_start_date) >= op.observation_period_start_date
+  
+  group by YEAR(ce1.condition_era_start_date)*100 + month(ce1.condition_era_start_date)
 )
 SELECT
   1020 as analysis_id,

--- a/inst/sql/sql_server/analyses/200.sql
+++ b/inst/sql/sql_server/analyses/200.sql
@@ -1,4 +1,5 @@
 -- 200	Number of persons with at least one visit occurrence, by visit_concept_id
+-- restricted to visits overlapping with observation period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 select 200 as analysis_id, 
@@ -7,6 +8,10 @@ select 200 as analysis_id,
 	COUNT_BIG(distinct vo1.PERSON_ID) as count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_200
 from
-	@cdmDatabaseSchema.visit_occurrence vo1
+	@cdmDatabaseSchema.visit_occurrence vo1 inner join 
+  @cdmDatabaseSchema.observation_period op on vo1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where vo1.visit_start_date <= op.observation_period_end_date and
+  isnull(vo1.visit_end_date,vo1.visit_start_date) >= op.observation_period_start_date
 group by vo1.visit_concept_id
 ;

--- a/inst/sql/sql_server/analyses/201.sql
+++ b/inst/sql/sql_server/analyses/201.sql
@@ -1,4 +1,5 @@
 -- 201	Number of visit occurrence records, by visit_concept_id
+-- restricted to visits overlapping with observation period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 select 201 as analysis_id, 
@@ -7,6 +8,10 @@ select 201 as analysis_id,
 	COUNT_BIG(vo1.PERSON_ID) as count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_201
 from
-	@cdmDatabaseSchema.visit_occurrence vo1
+	@cdmDatabaseSchema.visit_occurrence vo1 inner join 
+  @cdmDatabaseSchema.observation_period op on vo1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where vo1.visit_start_date <= op.observation_period_end_date and
+  isnull(vo1.visit_end_date,vo1.visit_start_date) >= op.observation_period_start_date
 group by vo1.visit_concept_id
 ;

--- a/inst/sql/sql_server/analyses/202.sql
+++ b/inst/sql/sql_server/analyses/202.sql
@@ -4,12 +4,17 @@
 WITH rawData AS (
   select
     vo1.visit_concept_id as stratum_1,
-    YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_2,
-    COUNT_BIG(distinct PERSON_ID) as count_value
+    YEAR(vo1.visit_start_date)*100 + month(vo1.visit_start_date) as stratum_2,
+    COUNT_BIG(distinct vo1.PERSON_ID) as count_value
   from
-    @cdmDatabaseSchema.visit_occurrence vo1
+    @cdmDatabaseSchema.visit_occurrence vo1 inner join 
+  @cdmDatabaseSchema.observation_period op on vo1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where vo1.visit_start_date <= op.observation_period_end_date and
+  isnull(vo1.visit_end_date,vo1.visit_start_date) >= op.observation_period_start_date
+  
   group by vo1.visit_concept_id,
-    YEAR(visit_start_date)*100 + month(visit_start_date)
+    YEAR(vo1.visit_start_date)*100 + month(vo1.visit_start_date)
 )
 SELECT
   202 as analysis_id,

--- a/inst/sql/sql_server/analyses/211.sql
+++ b/inst/sql/sql_server/analyses/211.sql
@@ -1,10 +1,15 @@
 -- 211	Distribution of length of stay by visit_concept_id
+-- restrict to visits inside observation period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_id) 
 with rawData(stratum_id, count_value) as
 (
   select visit_concept_id AS stratum_id, datediff(dd,visit_start_date,visit_end_date) as count_value
-  from @cdmDatabaseSchema.visit_occurrence
+  from @cdmDatabaseSchema.visit_occurrence vo inner join 
+  @cdmDatabaseSchema.observation_period op on vo.person_id = op.person_id
+  -- only include events that occur during observation period
+  where vo.visit_start_date >= op.observation_period_start_date and
+  isnull(vo.visit_end_date,vo.visit_start_date) <= op.observation_period_end_date
 ),
 overallStats (stratum_id, avg_value, stdev_value, min_value, max_value, total) as
 (

--- a/inst/sql/sql_server/analyses/220.sql
+++ b/inst/sql/sql_server/analyses/220.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(visit_start_date)*100 + month(visit_start_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(vo1.visit_start_date)*100 + month(vo1.visit_start_date) as stratum_1,
+    COUNT_BIG(vo1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.visit_occurrence vo1
-  group by YEAR(visit_start_date)*100 + month(visit_start_date)
+  @cdmDatabaseSchema.visit_occurrence vo1 inner join 
+  @cdmDatabaseSchema.observation_period op on vo1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where vo1.visit_start_date <= op.observation_period_end_date and
+  isnull(vo1.visit_end_date,vo1.visit_start_date) >= op.observation_period_start_date
+  
+  group by YEAR(vo1.visit_start_date)*100 + month(vo1.visit_start_date)
 )
 SELECT
   220 as analysis_id,

--- a/inst/sql/sql_server/analyses/403.sql
+++ b/inst/sql/sql_server/analyses/403.sql
@@ -3,9 +3,13 @@
 --HINT DISTRIBUTE_ON_KEY(count_value)
 with rawData(person_id, count_value) as
 (
-  select person_id, COUNT_BIG(distinct condition_concept_id) as count_value
-  from @cdmDatabaseSchema.condition_occurrence
-	group by person_id
+  select co.person_id, COUNT_BIG(distinct co.condition_concept_id) as count_value
+  from @cdmDatabaseSchema.condition_occurrence co inner join 
+  @cdmDatabaseSchema.observation_period op on co.person_id = op.person_id
+  -- only include events that occur during observation period
+  where co.condition_start_date <= op.observation_period_end_date and
+  isnull(co.condition_end_date,co.condition_start_date) >= op.observation_period_start_date
+	group by co.person_id
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as
 (

--- a/inst/sql/sql_server/analyses/420.sql
+++ b/inst/sql/sql_server/analyses/420.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(condition_start_date)*100 + month(condition_start_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(co1.condition_start_date)*100 + month(co1.condition_start_date) as stratum_1,
+    COUNT_BIG(co1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.condition_occurrence co1
-  group by YEAR(condition_start_date)*100 + month(condition_start_date)
+  @cdmDatabaseSchema.condition_occurrence co1 inner join 
+  @cdmDatabaseSchema.observation_period op on co1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where co1.condition_start_date <= op.observation_period_end_date and
+  isnull(co1.condition_end_date,co1.condition_start_date) >= op.observation_period_start_date
+  
+  group by YEAR(co1.condition_start_date)*100 + month(co1.condition_start_date)
 )
 SELECT
   420 as analysis_id,

--- a/inst/sql/sql_server/analyses/502.sql
+++ b/inst/sql/sql_server/analyses/502.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(death_date)*100 + month(death_date) as stratum_1,
-    COUNT_BIG(distinct PERSON_ID) as count_value
+    YEAR(d1.death_date)*100 + month(d1.death_date) as stratum_1,
+    COUNT_BIG(distinct d1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.death d1
-  group by YEAR(death_date)*100 + month(death_date)
+  @cdmDatabaseSchema.death d1 inner join 
+  @cdmDatabaseSchema.observation_period op on d1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where d1.death_date <= op.observation_period_end_date and
+  isnull(d1.death_date,d1.death_date) >= op.observation_period_start_date
+  
+  group by YEAR(d1.death_date)*100 + month(d1.death_date)
 )
 SELECT
   502 as analysis_id,

--- a/inst/sql/sql_server/analyses/502.sql
+++ b/inst/sql/sql_server/analyses/502.sql
@@ -10,8 +10,7 @@ WITH rawData AS (
   @cdmDatabaseSchema.observation_period op on d1.person_id = op.person_id
   -- only include events that occur during observation period
   where d1.death_date <= op.observation_period_end_date and
-  isnull(d1.death_date,d1.death_date) >= op.observation_period_start_date
-  
+    d1.death_date >= op.observation_period_start_date
   group by YEAR(d1.death_date)*100 + month(d1.death_date)
 )
 SELECT

--- a/inst/sql/sql_server/analyses/603.sql
+++ b/inst/sql/sql_server/analyses/603.sql
@@ -4,7 +4,11 @@
 with rawData(count_value) as
 (
   select COUNT_BIG(distinct po.procedure_concept_id) as count_value
-	from @cdmDatabaseSchema.procedure_occurrence po
+	from @cdmDatabaseSchema.procedure_occurrence po inner join 
+  @cdmDatabaseSchema.observation_period op on po.person_id = op.person_id
+  -- only include events that occur during observation period
+  where po.procedure_date <= op.observation_period_end_date and
+  po.procedure_date >= op.observation_period_start_date
 	group by po.person_id
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as

--- a/inst/sql/sql_server/analyses/620.sql
+++ b/inst/sql/sql_server/analyses/620.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(procedure_date)*100 + month(procedure_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(po1.procedure_date)*100 + month(po1.procedure_date) as stratum_1,
+    COUNT_BIG(po1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.procedure_occurrence po1
-  group by YEAR(procedure_date)*100 + month(procedure_date)
+  @cdmDatabaseSchema.procedure_occurrence po1 inner join 
+  @cdmDatabaseSchema.observation_period op on po1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where po1.procedure_date <= op.observation_period_end_date and
+  po1.procedure_date >= op.observation_period_start_date
+  
+  group by YEAR(po1.procedure_date)*100 + month(po1.procedure_date)
 )
 SELECT
   620 as analysis_id,

--- a/inst/sql/sql_server/analyses/703.sql
+++ b/inst/sql/sql_server/analyses/703.sql
@@ -8,7 +8,11 @@ with rawData(count_value) as
 	(
 		select de1.person_id, COUNT_BIG(distinct de1.drug_concept_id) as num_drugs
 		from
-		@cdmDatabaseSchema.drug_exposure de1
+		@cdmDatabaseSchema.drug_exposure de1 inner join 
+  @cdmDatabaseSchema.observation_period op on de1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where de1.drug_exposure_start_date <= op.observation_period_end_date and
+  isnull(de1.drug_exposure_end_date,de1.drug_exposure_start_date) >= op.observation_period_start_date
 		group by de1.person_id
 	) t0
 ),

--- a/inst/sql/sql_server/analyses/720.sql
+++ b/inst/sql/sql_server/analyses/720.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(de1.drug_exposure_start_date)*100 + month(de1.drug_exposure_start_date) as stratum_1,
+    COUNT_BIG(de1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.drug_exposure de1
-  group by YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date)
+  @cdmDatabaseSchema.drug_exposure de1 inner join 
+  @cdmDatabaseSchema.observation_period op on de1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where de1.drug_exposure_start_date <= op.observation_period_end_date and
+  isnull(de1.drug_exposure_end_date,de1.drug_exposure_start_date) >= op.observation_period_start_date
+  
+  group by YEAR(de1.drug_exposure_start_date)*100 + month(de1.drug_exposure_start_date)
 )
 SELECT
   720 as analysis_id,

--- a/inst/sql/sql_server/analyses/803.sql
+++ b/inst/sql/sql_server/analyses/803.sql
@@ -7,13 +7,12 @@ with rawData(count_value) as
   from
 	(
   	select o1.person_id, COUNT_BIG(distinct o1.observation_concept_id) as num_observations
-  	from
-  	@cdmDatabaseSchema.observation o1 inner join 
-  @cdmDatabaseSchema.observation_period op on o1.person_id = op.person_id
-  -- only include events that occur during observation period
-  where o1.observation_date <= op.observation_period_end_date and
-  isnull(o1.observation_date,o1.observation_date) >= op.observation_period_start_date
-  	group by o1.person_id
+  	from @cdmDatabaseSchema.observation o1 inner join @cdmDatabaseSchema.observation_period op 
+  	  on o1.person_id = op.person_id
+    -- only include events that occur during observation period
+    where o1.observation_date <= op.observation_period_end_date and
+      o1.observation_date >= op.observation_period_start_date
+    group by o1.person_id
 	) t0
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as

--- a/inst/sql/sql_server/analyses/803.sql
+++ b/inst/sql/sql_server/analyses/803.sql
@@ -8,7 +8,11 @@ with rawData(count_value) as
 	(
   	select o1.person_id, COUNT_BIG(distinct o1.observation_concept_id) as num_observations
   	from
-  	@cdmDatabaseSchema.observation o1
+  	@cdmDatabaseSchema.observation o1 inner join 
+  @cdmDatabaseSchema.observation_period op on o1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where o1.observation_date <= op.observation_period_end_date and
+  isnull(o1.observation_date,o1.observation_date) >= op.observation_period_start_date
   	group by o1.person_id
 	) t0
 ),

--- a/inst/sql/sql_server/analyses/820.sql
+++ b/inst/sql/sql_server/analyses/820.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(observation_date)*100 + month(observation_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(o1.observation_date)*100 + month(o1.observation_date) as stratum_1,
+    COUNT_BIG(o1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.observation o1
-  group by YEAR(observation_date)*100 + month(observation_date)
+  @cdmDatabaseSchema.observation o1 inner join 
+  @cdmDatabaseSchema.observation_period op on o1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where o1.observation_date <= op.observation_period_end_date and
+  o1.observation_date >= op.observation_period_start_date
+  
+  group by YEAR(o1.observation_date)*100 + month(o1.observation_date)
 )
 SELECT
   820 as analysis_id,

--- a/inst/sql/sql_server/analyses/903.sql
+++ b/inst/sql/sql_server/analyses/903.sql
@@ -4,7 +4,11 @@
 with rawData(count_value) as
 (
   select COUNT_BIG(distinct de1.drug_concept_id) as count_value
-	from @cdmDatabaseSchema.drug_era de1
+	from @cdmDatabaseSchema.drug_era de1 inner join 
+  @cdmDatabaseSchema.observation_period op on de1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where de1.drug_era_start_date <= op.observation_period_end_date and
+  isnull(de1.drug_era_end_date,de1.drug_era_start_date) >= op.observation_period_start_date
 	group by de1.person_id
 ),
 overallStats (avg_value, stdev_value, min_value, max_value, total) as

--- a/inst/sql/sql_server/analyses/920.sql
+++ b/inst/sql/sql_server/analyses/920.sql
@@ -3,11 +3,16 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 WITH rawData AS (
   select
-    YEAR(drug_era_start_date)*100 + month(drug_era_start_date) as stratum_1,
-    COUNT_BIG(PERSON_ID) as count_value
+    YEAR(de1.drug_era_start_date)*100 + month(de1.drug_era_start_date) as stratum_1,
+    COUNT_BIG(de1.PERSON_ID) as count_value
   from
-  @cdmDatabaseSchema.drug_era de1
-  group by YEAR(drug_era_start_date)*100 + month(drug_era_start_date)
+  @cdmDatabaseSchema.drug_era de1 inner join 
+  @cdmDatabaseSchema.observation_period op on de1.person_id = op.person_id
+  -- only include events that occur during observation period
+  where de1.drug_era_start_date <= op.observation_period_end_date and
+  isnull(de1.drug_era_end_date,de1.drug_era_start_date) >= op.observation_period_start_date
+  
+  group by YEAR(de1.drug_era_start_date)*100 + month(de1.drug_era_start_date)
 )
 SELECT
   920 as analysis_id,


### PR DESCRIPTION
As the CDM now allows records outside the observation period - this messes up some of the achilles plots.

I edited the data dashboard and visit analyses to restrict to things that overlap with an observation period.

for analysis 211 - I restricted to visits contained within an observation period rather than overlapping