### PR TITLE
Optionally read DB username and password from dedicated env vars

### DIFF
--- a/docker-run
+++ b/docker-run
@@ -6,13 +6,14 @@ library(httr)
 
 # Get passed environment variables.
 env_var_names <- list("ACHILLES_SOURCE", "ACHILLES_DB_URI",
+                      "ACHILLES_DB_USERNAME", "ACHILLES_DB_PASSWORD",
                       "ACHILLES_CDM_SCHEMA", "ACHILLES_VOCAB_SCHEMA",
                       "ACHILLES_RES_SCHEMA", "ACHILLES_OUTPUT_BASE",
                       "ACHILLES_CDM_VERSION", "ACHILLES_NUM_THREADS")
 env_vars <- Sys.getenv(env_var_names, unset=NA)
 
 # Replace unset environement variables with defaults.
-default_vars <- list("N/A", "postgresql://localhost/postgres",
+default_vars <- list("N/A", "postgresql://localhost/postgres", "", "",
                      "public", "public", "public", "./output", "5", "1")
 env_vars[is.na(env_vars)] <- default_vars[is.na(env_vars)]
 
@@ -32,8 +33,14 @@ db_conf <- parse_url(env_vars$ACHILLES_DB_URI)
 server <- paste(db_conf$hostname, db_conf$path, sep="/")
 
 # Create connection details using DatabaseConnector utility.
+db_username <- ifelse(env_vars$ACHILLES_DB_USERNAME == "" | is.na(env_vars$ACHILLES_DB_USERNAME),
+    db_conf$username,
+    env_vars$ACHILLES_DB_USERNAME)
+db_password <- ifelse(env_vars$ACHILLES_DB_PASSWORD == "" | is.na(env_vars$ACHILLES_DB_PASSWORD),
+    db_conf$password,
+    env_vars$ACHILLES_DB_PASSWORD)
 connectionDetails <- createConnectionDetails(
-    dbms=db_conf$scheme, user=db_conf$username, password=db_conf$password,
+    dbms=db_conf$scheme, user=db_username, password=db_password,
     server=server, port=db_conf$port
 )
 
@@ -53,7 +60,7 @@ if (length(args) == 0 || args[1] != "heel") {
         createIndices=createIndices,
         numThreads=env_vars$ACHILLES_NUM_THREADS
     )
-    
+
 } else {
 
     # Run Achilles Heel only

--- a/env_vars.sample
+++ b/env_vars.sample
@@ -1,5 +1,7 @@
 ACHILLES_SOURCE=<source_name>
 ACHILLES_DB_URI=<db_uri>
+ACHILLES_DB_PASSWORD=<db_password>
+ACHILLES_DB_USERBAME=<db_username>
 ACHILLES_CDM_SCHEMA=<cdm_schema>
 ACHILLES_VOCAB_SCHEMA=<vocab_schema>
 ACHILLES_RES_SCHEMA=<results_schema>


### PR DESCRIPTION
ACHILLES_DB_USERNAME and ACHILLES_DB_PASSWORD can be used in place of providing
the credentials within the JDBC URI.