### PR TITLE
Added github workflow for building the container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
+env:
+  DOCKER_IMAGE: ohdsi/achilles
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: |
+            docker.io/${{ env.DOCKER_IMAGE }}
+          tag-sha: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+      - name: Print image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
For this to work, two repository secrets `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN` with access to the docker.io/achilles Docker hub repository will need to be set-up. This pushes a new container image on every commit to master (tagged as `master` and the git commit SHA also, the image is also tagged as any git tag (see https://hub.docker.com/repository/docker/chgl/achilles/tags?page=1&ordering=last_updated for example)).

For availability, it would also be great if an OHDSI organization on quay.io and/or GHCR were set-up so the final image can be pushed to both quay.io, Docker Hub (docker.io), and ghcr.io (GitHub Container Registry).