### PR TITLE
Fixes Issue 425

### DIFF
--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -64,7 +64,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 413,0,0,,Number of condition occurrence records with invalid visit_id,,,,,
 420,0,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,
 425,0,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,
-424,0,0,,Number of co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,,
+424,0,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases
 500,0,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,
 501,0,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,
 502,0,0,,Number of persons by death month,calendar month,,,,
@@ -92,7 +92,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 613,0,0,,Number of procedure occurrence records with invalid visit_id,,,,,
 620,0,0,,Number of procedure occurrence records  by procedure occurrence start month,calendar month,,,,
 625,0,0,,Number of procedure_occurrence records by procedure_source_concept_id,procedure_source_concept_id,,,,
-624,0,0,,Number of co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,,
+624,0,0,,Number of distinct people with co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,num_people,num_cases
 691,0,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,
 700,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,
 701,0,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,
@@ -111,7 +111,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 717,1,0,,Distribution of quantity by drug_concept_id,drug_concept_id,,,,
 720,0,0,,Number of drug exposure records  by drug exposure start month,calendar month,,,,
 725,0,0,,Number of drug_exposure records by drug_source_concept_id,drug_source_concept_id,,,,
-724,0,0,,Number of co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,,
+724,0,0,,Number of distinct people with co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,num_people,num_cases
 791,0,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,
 800,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,
 801,0,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,
@@ -133,7 +133,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 826,0,0,,Number of observation records by value_as_concept_id,value_as_concept_id,,,,
 827,0,0,,Number of observation records by unit_concept_id,unit_as_concept_id,,,,
 825,0,0,,Number of observation records by observation_source_concept_id,observation_source_concept_id,,,,
-824,0,0,,Number of co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,,
+824,0,0,,Number of distinct people with co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,num_people,num_cases
 891,0,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,
 900,0,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,
 901,0,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,
@@ -224,7 +224,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 1826,0,0,,Number of measurement records by value_as_concept_id,value_as_concept_id,,,,
 1827,0,0,,Number of measurement records by unit_concept_id,unit_as_concept_id,,,,
 1825,0,0,,Number of measurement records by measurement_source_concept_id,measurement_source_concept_id,,,,
-1824,0,0,,Number of co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,,
+1824,0,0,,Number of distinct people with co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,num_people,num_cases
 1891,0,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,
 1900,0,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,
 2000,0,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,

--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -1,241 +1,241 @@
-ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME
-0,-1,0,,Source name,,,,,
-1,0,0,,Number of persons,,,,,
-2,0,0,,Number of persons by gender,gender_concept_id,,,,
-3,0,0,,Number of persons by year of birth,year_of_birth,,,,
-4,0,0,,Number of persons by race,race_concept_id,,,,
-5,0,0,,Number of persons by ethnicity,ethnicity_concept_id,,,,
-7,0,0,,Number of persons with invalid provider_id,,,,,
-8,0,0,,Number of persons with invalid location_id,,,,,
-9,0,0,,Number of persons with invalid care_site_id,,,,,
-10,0,0,,Number of all persons by year of birth by gender,year_of_birth,gender_concept_id,,,
-11,0,0,,Number of non-deceased persons by year of birth by gender,year_of_birth,gender_concept_id,,,
-12,0,0,,Number of persons by race and ethnicity,race_concept_id,ethnicity_concept_id,,,
-101,0,0,,"Number of persons by age, with age at first observation period",age,,,,
-102,0,0,,"Number of persons by gender by age, with age at first observation period",gender_concept_id,age,,,
-103,1,0,,Distribution of age at first observation period,,,,,
-104,1,0,,Distribution of age at first observation period by gender,gender_concept_id,,,,
-105,1,0,,Length of observation (days) of first observation period,,,,,
-106,1,0,,Length of observation (days) of first observation period by gender,gender_concept_id,,,,
-107,1,0,,Length of observation (days) of first observation period by age decile,age decile,,,,
-108,0,0,,"Number of persons by length of observation period, in 30d increments",Observation period length 30d increments,,,,
-109,0,0,,Number of persons with continuous observation in each year,calendar year,,,,
-110,0,0,,Number of persons with continuous observation in each month,calendar month,,,,
-111,0,0,,Number of persons by observation period start month,calendar month,,,,
-112,0,0,,Number of persons by observation period end month,calendar month,,,,
-113,0,0,,Number of persons by number of observation periods,number of observation periods,,,,
-114,0,0,,Number of persons with observation period before year-of-birth,,,,,
-115,0,0,,Number of persons with observation period end < observation period start,,,,,
-116,0,0,,Number of persons with at least one day of observation in each year by gender and age decile,calendar year,gender_concept_id,age decile,,
-117,0,0,,Number of persons with at least one day of observation in each month,calendar month,,,,
-118,0,0,,Number of observation periods with invalid person_id,,,,,
-119,0,0,,Number of observation period records by period_type_concept_id,period_type_concept_id,,,,
-200,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id",visit_concept_id,,,,
-201,0,0,,"Number of visit occurrence records, by visit_concept_id",visit_concept_id,,,,
-202,0,0,,"Number of persons by visit occurrence start month, by visit_concept_id",visit_concept_id,calendar month,,,
-203,1,0,,Number of distinct visit occurrence concepts per person,,,,,
-204,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile",visit_concept_id,calendar year,gender_concept_id,age decile,
-206,1,0,,Distribution of age by visit_concept_id,visit_concept_id,gender_concept_id,,,
-207,0,0,,Number of visit records with invalid person_id,,,,,
-208,0,0,,Number of visit records outside valid observation period,,,,,
-209,0,0,,Number of visit records with end date < start date,,,,,
-210,0,0,,Number of visit records with invalid care_site_id,,,,,
-211,1,0,,Distribution of length of stay by visit_concept_id,visit_concept_id,,,,
-212,0,0,,"Number of persons with at least one visit occurrence, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,
-220,0,0,,Number of visit occurrence records by visit occurrence start month,calendar month,,,,
-221,0,0,,Number of persons by visit start year,calendar year,,,,
-225,0,0,,Number of visit_occurrence records by visit_source_concept_id,visit_source_concept_id,,,,
-226,0,0,,Number of records by domain by visit_concept_id,visit_source_concept_id,cdm_table_name,,,
-300,0,0,,Number of providers,,,,,
-301,0,0,,Number of providers by specialty concept_id,specialty_concept_id,,,,
-302,0,0,,Number of providers with invalid care site id,,,,,
-325,0,0,,Number of provider records by specialty_source_concept_id,specialty_source_concept_id,,,,
-400,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id",condition_concept_id,,,,
-401,0,0,,"Number of condition occurrence records, by condition_concept_id",condition_concept_id,,,,
-402,0,0,,"Number of persons by condition occurrence start month, by condition_concept_id",condition_concept_id,calendar month,,,
-403,1,0,,Number of distinct condition occurrence concepts per person,,,,,
-404,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,
-405,0,0,,"Number of condition occurrence records, by condition_concept_id by condition_type_concept_id",condition_concept_id,condition_type_concept_id,,,
-406,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,
-409,0,0,,Number of condition occurrence records with invalid person_id,,,,,
-410,0,0,,Number of condition occurrence records outside valid observation period,,,,,
-411,0,0,,Number of condition occurrence records with end date < start date,,,,,
-412,0,0,,Number of condition occurrence records with invalid provider_id,,,,,
-413,0,0,,Number of condition occurrence records with invalid visit_id,,,,,
-420,0,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,
-425,0,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,
-424,0,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases
-500,0,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,
-501,0,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,
-502,0,0,,Number of persons by death month,calendar month,,,,
-504,0,0,,"Number of persons with a death, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,
-505,0,0,,"Number of death records, by death_type_concept_id",death_type_concept_id,,,,
-506,1,0,,Distribution of age at death by gender,gender_concept_id,,,,
-509,0,0,,Number of death records with invalid person_id,,,,,
-510,0,0,,Number of death records outside valid observation period,,,,,
-511,1,0,,Distribution of time from death to last condition,,,,,
-512,1,0,,Distribution of time from death to last drug,,,,,
-513,1,0,,Distribution of time from death to last visit,,,,,
-514,1,0,,Distribution of time from death to last procedure,,,,,
-515,1,0,,Distribution of time from death to last observation,,,,,
-525,0,0,,Number of death records by cause_source_concept_id,cause_source_concept_id,,,,
-600,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id",procedure_concept_id,,,,
-601,0,0,,"Number of procedure occurrence records, by procedure_concept_id",procedure_concept_id,,,,
-602,0,0,,"Number of persons by procedure occurrence start month, by procedure_concept_id",procedure_concept_id,calendar month,,,
-603,1,0,,Number of distinct procedure occurrence concepts per person,,,,,
-604,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile",procedure_concept_id,calendar year,gender_concept_id,age decile,
-605,0,0,,"Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id",procedure_concept_id,procedure_type_concept_id,,,
-606,1,0,,Distribution of age by procedure_concept_id,procedure_concept_id,gender_concept_id,,,
-609,0,0,,Number of procedure occurrence records with invalid person_id,,,,,
-610,0,0,,Number of procedure occurrence records outside valid observation period,,,,,
-612,0,0,,Number of procedure occurrence records with invalid provider_id,,,,,
-613,0,0,,Number of procedure occurrence records with invalid visit_id,,,,,
-620,0,0,,Number of procedure occurrence records  by procedure occurrence start month,calendar month,,,,
-625,0,0,,Number of procedure_occurrence records by procedure_source_concept_id,procedure_source_concept_id,,,,
-624,0,0,,Number of distinct people with co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,num_people,num_cases
-691,0,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,
-700,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,
-701,0,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,
-702,0,0,,"Number of persons by drug exposure start month, by drug_concept_id",drug_concept_id,calendar month,,,
-703,1,0,,Number of distinct drug exposure concepts per person,,,,,
-704,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,
-705,0,0,,"Number of drug exposure records, by drug_concept_id by drug_type_concept_id",drug_concept_id,drug_type_concept_id,,,
-706,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,
-709,0,0,,Number of drug exposure records with invalid person_id,,,,,
-710,0,0,,Number of drug exposure records outside valid observation period,,,,,
-711,0,0,,Number of drug exposure records with end date < start date,,,,,
-712,0,0,,Number of drug exposure records with invalid provider_id,,,,,
-713,0,0,,Number of drug exposure records with invalid visit_id,,,,,
-715,1,0,,Distribution of days_supply by drug_concept_id,drug_concept_id,,,,
-716,1,0,,Distribution of refills by drug_concept_id,drug_concept_id,,,,
-717,1,0,,Distribution of quantity by drug_concept_id,drug_concept_id,,,,
-720,0,0,,Number of drug exposure records  by drug exposure start month,calendar month,,,,
-725,0,0,,Number of drug_exposure records by drug_source_concept_id,drug_source_concept_id,,,,
-724,0,0,,Number of distinct people with co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,num_people,num_cases
-791,0,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,
-800,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,
-801,0,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,
-802,0,0,,"Number of persons by observation occurrence start month, by observation_concept_id",observation_concept_id,calendar month,,,
-803,1,0,,Number of distinct observation occurrence concepts per person,,,,,
-804,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile",observation_concept_id,calendar year,gender_concept_id,age decile,
-805,0,0,,"Number of observation occurrence records, by observation_concept_id by observation_type_concept_id",observation_concept_id,observation_type_concept_id,,,
-806,1,0,,Distribution of age by observation_concept_id,observation_concept_id,gender_concept_id,,,
-807,0,0,,"Number of observation occurrence records, by observation_concept_id and unit_concept_id",observation_concept_id,unit_concept_id,,,
-809,0,0,,Number of observation records with invalid person_id,,,,,
-810,0,0,,Number of observation records outside valid observation period,,,,,
-812,0,0,,Number of observation records with invalid provider_id,,,,,
-813,0,0,,Number of observation records with invalid visit_id,,,,,
-814,0,0,,"Number of observation records with no value (numeric, string, or concept)",,,,,
-815,1,0,,"Distribution of numeric values, by observation_concept_id and unit_concept_id",,,,,
-820,0,0,,Number of observation records  by observation start month,calendar month,,,,
-822,0,0,,"Number of observation records, by observation_concept_id and value_as_concept_id",observation_concept_id,value_as_concept_id,,,
-823,0,0,,"Number of observation records, by observation_concept_id and qualifier_concept_id",observation_concept_id,qualifier_concept_id,,,
-826,0,0,,Number of observation records by value_as_concept_id,value_as_concept_id,,,,
-827,0,0,,Number of observation records by unit_concept_id,unit_as_concept_id,,,,
-825,0,0,,Number of observation records by observation_source_concept_id,observation_source_concept_id,,,,
-824,0,0,,Number of distinct people with co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,num_people,num_cases
-891,0,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,
-900,0,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,
-901,0,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,
-902,0,0,,"Number of persons by drug era start month, by drug_concept_id",drug_concept_id,calendar month,,,
-903,1,0,,Number of distinct drug era concepts per person,,,,,
-904,0,0,,"Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,
-906,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,
-907,1,0,,"Distribution of drug era length, by drug_concept_id",drug_concept_id,,,,
-908,0,0,,Number of drug eras without valid person,,,,,
-909,0,0,,Number of drug eras outside valid observation period,,,,,
-910,0,0,,Number of drug eras with end date < start date,,,,,
-920,0,0,,Number of drug era records  by drug era start month,calendar month,,,,
-1000,0,0,,"Number of persons with at least one condition era, by condition_concept_id",condition_concept_id,,,,
-1001,0,0,,"Number of condition era records, by condition_concept_id",condition_concept_id,,,,
-1002,0,0,,"Number of persons by condition era start month, by condition_concept_id",condition_concept_id,calendar month,,,
-1003,1,0,,Number of distinct condition era concepts per person,,,,,
-1004,0,0,,"Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,
-1006,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,
-1007,1,0,,"Distribution of condition era length, by condition_concept_id",condition_concept_id,,,,
-1008,0,0,,Number of condition eras without valid person,,,,,
-1009,0,0,,Number of condition eras outside valid observation period,,,,,
-1010,0,0,,Number of condition eras with end date < start date,,,,,
-1020,0,0,,Number of condition era records by condition era start month,calendar month,,,,
-1100,0,0,,Number of persons by location 3-digit zip,3-digit zip,,,,
-1101,0,0,,Number of persons by location state,state,,,,
-1102,0,0,,Number of care sites by location 3-digit zip,3-digit zip,,,,
-1103,0,0,,Number of care sites by location state,state,,,,
-1200,0,0,,Number of persons by place of service,place_of_service_concept_id,,,,
-1201,0,0,,Number of visits by place of service,place_of_service_concept_id,,,,
-1202,0,0,,Number of care sites by place of service,place_of_service_concept_id,,,,
-1203,0,0,,Number of visits by place of service discharge type,discharge_to_concept_id,,,,
-1406,1,0,,Length of payer plan (days) of first payer plan period by gender,gender_concept_id,,,,
-1407,1,0,,Length of payer plan (days) of first payer plan period by age decile,age_decile,,,,
-1408,0,0,,"Number of persons by length of payer plan period, in 30d increments",payer plan period length 30d increments,,,,
-1409,0,0,,Number of persons with continuous payer plan in each year,calendar year,,,,
-1410,0,0,,Number of persons with continuous payer plan in each month,calendar month,,,,
-1411,0,0,,Number of persons by payer plan period start month,calendar month,,,,
-1412,0,0,,Number of persons by payer plan period end month,calendar month,,,,
-1413,0,0,,Number of persons by number of payer plan periods,number of payer plan periods,,,,
-1414,0,0,,Number of persons with payer plan period before year-of-birth,,,,,
-1415,0,0,,Number of persons with payer plan period end < payer plan period start,,,,,
-1425,0,0,,Number of payer_plan_period records by payer_source_concept_id,payer_source_concept_id,,,,
-1500,0,1,,Number of drug cost records with invalid drug exposure id,,,,,
-1501,0,1,,Number of drug cost records with invalid payer plan period id,,,,,
-1502,1,1,paid_copay,"Distribution of paid copay, by drug_concept_id",drug_concept_id,,,,
-1503,1,1,paid_coinsurance,"Distribution of paid coinsurance, by drug_concept_id",drug_concept_id,,,,
-1504,1,1,paid_toward_deductible,"Distribution of paid toward deductible, by drug_concept_id",drug_concept_id,,,,
-1505,1,1,paid_by_payer,"Distribution of paid by payer, by drug_concept_id",drug_concept_id,,,,
-1506,1,1,paid_by_coordination_benefits,"Distribution of paid by coordination of benefit, by drug_concept_id",drug_concept_id,,,,
-1507,1,1,total_out_of_pocket,"Distribution of total out-of-pocket, by drug_concept_id",drug_concept_id,,,,
-1508,1,1,total_paid,"Distribution of total paid, by drug_concept_id",drug_concept_id,,,,
-1509,1,1,ingredient_cost,"Distribution of ingredient_cost, by drug_concept_id",drug_concept_id,,,,
-1510,1,1,dispensing_fee,"Distribution of dispensing fee, by drug_concept_id",drug_concept_id,,,,
-1511,1,1,average_wholesale_price,"Distribution of average wholesale price, by drug_concept_id",drug_concept_id,,,,
-1600,0,1,,Number of procedure cost records with invalid procedure occurrence id,,,,,
-1601,0,1,,Number of procedure cost records with invalid payer plan period id,,,,,
-1602,1,1,paid_copay,"Distribution of paid copay, by procedure_concept_id",procedure_concept_id,,,,
-1603,1,1,paid_coinsurance,"Distribution of paid coinsurance, by procedure_concept_id",procedure_concept_id,,,,
-1604,1,1,paid_toward_deductible,"Distribution of paid toward deductible, by procedure_concept_id",procedure_concept_id,,,,
-1605,1,1,paid_by_payer,"Distribution of paid by payer, by procedure_concept_id",procedure_concept_id,,,,
-1606,1,1,paid_by_coordination_benefits,"Distribution of paid by coordination of benefit, by procedure_concept_id",procedure_concept_id,,,,
-1607,1,1,total_out_of_pocket,"Distribution of total out-of-pocket, by procedure_concept_id",procedure_concept_id,,,,
-1608,1,1,total_paid,"Distribution of total paid, by procedure_concept_id",procedure_concept_id,,,,
-1610,0,1,,Number of records by revenue_code_concept_id,revenue_code_concept_id,,,,
-1700,0,0,,Number of records by cohort_concept_id,cohort_concept_id,,,,
-1701,0,0,,Number of records with cohort end date < cohort start date,,,,,
-1800,0,0,,"Number of persons with at least one measurement occurrence, by measurement_concept_id",measurement_concept_id,,,,
-1801,0,0,,"Number of measurement occurrence records, by measurement_concept_id",measurement_concept_id,,,,
-1802,0,0,,"Number of persons by measurement occurrence start month, by measurement_concept_id",measurement_concept_id,calendar month,,,
-1803,1,0,,Number of distinct mesurement occurrence concepts per person,,,,,
-1804,0,0,,"Number of persons with at least one mesurement  occurrence, by measurement_concept_id by calendar year by gender by age decile",measurement_concept_id,calendar year,gender_concept_id,age decile,
-1805,0,0,,"Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id",measurement_concept_id,measurement_type_concept_id,,,
-1806,1,0,,Distribution of age by measurement_concept_id,measurement_concept_id,gender_concept_id,,,
-1807,0,0,,"Number of measurement occurrence records, by measurement_concept_id and unit_concept_id",measurement_concept_id,unit_concept_id,,,
-1809,0,0,,Number of measurement records with invalid person_id,,,,,
-1810,0,0,,Number of measurement records outside valid observation period,,,,,
-1812,0,0,,Number of measurement records with invalid provider_id,,,,,
-1813,0,0,,Number of measurement records with invalid visit_id,,,,,
-1814,0,0,,"Number of measurement records with no value (numeric, string, or concept)",,,,,
-1815,1,0,,"Distribution of numeric values, by measurement_concept_id and unit_concept_id",,,,,
-1816,1,0,,"Distribution of low range, by measurement_concept_id and unit_concept_id",,,,,
-1817,1,0,,"Distribution of high range, by measurement_concept_id and unit_concept_id",,,,,
-1818,0,0,,"Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id",,,,,
-1820,0,0,,Number of measurement records  by measurement start month,calendar month,,,,
-1821,0,0,,Number of measurement records with no numeric value,,,,,
-1822,0,0,,"Number of measurement records, by measurement_concept_id and value_as_concept_id",measurement_concept_id,value_as_concept_id,,,
-1823,0,0,,"Number of measurement records, by measurement_concept_id and operator_concept_id",measurement_concept_id,operator_concept_id,,,
-1826,0,0,,Number of measurement records by value_as_concept_id,value_as_concept_id,,,,
-1827,0,0,,Number of measurement records by unit_concept_id,unit_as_concept_id,,,,
-1825,0,0,,Number of measurement records by measurement_source_concept_id,measurement_source_concept_id,,,,
-1824,0,0,,Number of distinct people with co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,num_people,num_cases
-1891,0,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,
-1900,0,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,
-2000,0,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,
-2001,0,0,,Number of patients with at least 1 Dx and 1 Proc,,,,,
-2002,0,0,,"Number of patients with at least 1 Meas, 1 Dx and 1 Rx",,,,,
-2003,0,0,,Number of patients with at least 1 Visit,,,,,
-2100,0,0,,"Number of persons with at least one device exposure, by device_concept_id",device_concept_id,,,,
-2101,0,0,,"Number of device exposure records, by device_concept_id",device_concept_id,,,,
-2102,0,0,,"Number of persons by device records  start month, by device_concept_id",device_concept_id,calendar month,,,
-2104,0,0,,"Number of persons with at least one device exposure, by device_concept_id by calendar year by gender by age decile",device_concept_id,calendar year,gender_concept_id,age decile,
-2105,0,0,,"Number of device exposure records, by device_concept_id by device_type_concept_id",device_concept_id,device_type_concept_id,,,
-2125,0,0,,Number of device_exposure records by device_source_concept_id,device_source_concept_id,,,,
-2200,0,0,,Number of persons with at least one note by  note_type_concept_id,note_type_concept_id,,,,
-2201,0,0,,"Number of note records, by note_type_concept_id",note_type_concept_id,,,,
+ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,DEFAULT
+0,-1,0,,Source name,,,,,,1
+1,0,0,,Number of persons,,,,,,1
+2,0,0,,Number of persons by gender,gender_concept_id,,,,,1
+3,0,0,,Number of persons by year of birth,year_of_birth,,,,,1
+4,0,0,,Number of persons by race,race_concept_id,,,,,1
+5,0,0,,Number of persons by ethnicity,ethnicity_concept_id,,,,,1
+7,0,0,,Number of persons with invalid provider_id,,,,,,1
+8,0,0,,Number of persons with invalid location_id,,,,,,1
+9,0,0,,Number of persons with invalid care_site_id,,,,,,1
+10,0,0,,Number of all persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1
+11,0,0,,Number of non-deceased persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1
+12,0,0,,Number of persons by race and ethnicity,race_concept_id,ethnicity_concept_id,,,,1
+101,0,0,,"Number of persons by age, with age at first observation period",age,,,,,1
+102,0,0,,"Number of persons by gender by age, with age at first observation period",gender_concept_id,age,,,,1
+103,1,0,,Distribution of age at first observation period,,,,,,1
+104,1,0,,Distribution of age at first observation period by gender,gender_concept_id,,,,,1
+105,1,0,,Length of observation (days) of first observation period,,,,,,1
+106,1,0,,Length of observation (days) of first observation period by gender,gender_concept_id,,,,,1
+107,1,0,,Length of observation (days) of first observation period by age decile,age decile,,,,,1
+108,0,0,,"Number of persons by length of observation period, in 30d increments",Observation period length 30d increments,,,,,1
+109,0,0,,Number of persons with continuous observation in each year,calendar year,,,,,1
+110,0,0,,Number of persons with continuous observation in each month,calendar month,,,,,1
+111,0,0,,Number of persons by observation period start month,calendar month,,,,,1
+112,0,0,,Number of persons by observation period end month,calendar month,,,,,1
+113,0,0,,Number of persons by number of observation periods,number of observation periods,,,,,1
+114,0,0,,Number of persons with observation period before year-of-birth,,,,,,1
+115,0,0,,Number of persons with observation period end < observation period start,,,,,,1
+116,0,0,,Number of persons with at least one day of observation in each year by gender and age decile,calendar year,gender_concept_id,age decile,,,1
+117,0,0,,Number of persons with at least one day of observation in each month,calendar month,,,,,1
+118,0,0,,Number of observation periods with invalid person_id,,,,,,1
+119,0,0,,Number of observation period records by period_type_concept_id,period_type_concept_id,,,,,1
+200,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id",visit_concept_id,,,,,1
+201,0,0,,"Number of visit occurrence records, by visit_concept_id",visit_concept_id,,,,,1
+202,0,0,,"Number of persons by visit occurrence start month, by visit_concept_id",visit_concept_id,calendar month,,,,1
+203,1,0,,Number of distinct visit occurrence concepts per person,,,,,,1
+204,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile",visit_concept_id,calendar year,gender_concept_id,age decile,,1
+206,1,0,,Distribution of age by visit_concept_id,visit_concept_id,gender_concept_id,,,,1
+207,0,0,,Number of visit records with invalid person_id,,,,,,1
+208,0,0,,Number of visit records outside valid observation period,,,,,,1
+209,0,0,,Number of visit records with end date < start date,,,,,,1
+210,0,0,,Number of visit records with invalid care_site_id,,,,,,1
+211,1,0,,Distribution of length of stay by visit_concept_id,visit_concept_id,,,,,1
+212,0,0,,"Number of persons with at least one visit occurrence, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1
+220,0,0,,Number of visit occurrence records by visit occurrence start month,calendar month,,,,,1
+221,0,0,,Number of persons by visit start year,calendar year,,,,,1
+225,0,0,,Number of visit_occurrence records by visit_source_concept_id,visit_source_concept_id,,,,,1
+226,0,0,,Number of records by domain by visit_concept_id,visit_source_concept_id,cdm_table_name,,,,1
+300,0,0,,Number of providers,,,,,,1
+301,0,0,,Number of providers by specialty concept_id,specialty_concept_id,,,,,1
+302,0,0,,Number of providers with invalid care site id,,,,,,1
+325,0,0,,Number of provider records by specialty_source_concept_id,specialty_source_concept_id,,,,,1
+400,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id",condition_concept_id,,,,,1
+401,0,0,,"Number of condition occurrence records, by condition_concept_id",condition_concept_id,,,,,1
+402,0,0,,"Number of persons by condition occurrence start month, by condition_concept_id",condition_concept_id,calendar month,,,,1
+403,1,0,,Number of distinct condition occurrence concepts per person,,,,,,1
+404,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1
+405,0,0,,"Number of condition occurrence records, by condition_concept_id by condition_type_concept_id",condition_concept_id,condition_type_concept_id,,,,1
+406,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1
+409,0,0,,Number of condition occurrence records with invalid person_id,,,,,,1
+410,0,0,,Number of condition occurrence records outside valid observation period,,,,,,1
+411,0,0,,Number of condition occurrence records with end date < start date,,,,,,1
+412,0,0,,Number of condition occurrence records with invalid provider_id,,,,,,1
+413,0,0,,Number of condition occurrence records with invalid visit_id,,,,,,1
+420,0,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,,1
+425,0,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,,1
+424,0,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases,0
+500,0,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,,1
+501,0,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,,1
+502,0,0,,Number of persons by death month,calendar month,,,,,1
+504,0,0,,"Number of persons with a death, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1
+505,0,0,,"Number of death records, by death_type_concept_id",death_type_concept_id,,,,,1
+506,1,0,,Distribution of age at death by gender,gender_concept_id,,,,,1
+509,0,0,,Number of death records with invalid person_id,,,,,,1
+510,0,0,,Number of death records outside valid observation period,,,,,,1
+511,1,0,,Distribution of time from death to last condition,,,,,,1
+512,1,0,,Distribution of time from death to last drug,,,,,,1
+513,1,0,,Distribution of time from death to last visit,,,,,,1
+514,1,0,,Distribution of time from death to last procedure,,,,,,1
+515,1,0,,Distribution of time from death to last observation,,,,,,1
+525,0,0,,Number of death records by cause_source_concept_id,cause_source_concept_id,,,,,1
+600,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id",procedure_concept_id,,,,,1
+601,0,0,,"Number of procedure occurrence records, by procedure_concept_id",procedure_concept_id,,,,,1
+602,0,0,,"Number of persons by procedure occurrence start month, by procedure_concept_id",procedure_concept_id,calendar month,,,,1
+603,1,0,,Number of distinct procedure occurrence concepts per person,,,,,,1
+604,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile",procedure_concept_id,calendar year,gender_concept_id,age decile,,1
+605,0,0,,"Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id",procedure_concept_id,procedure_type_concept_id,,,,1
+606,1,0,,Distribution of age by procedure_concept_id,procedure_concept_id,gender_concept_id,,,,1
+609,0,0,,Number of procedure occurrence records with invalid person_id,,,,,,1
+610,0,0,,Number of procedure occurrence records outside valid observation period,,,,,,1
+612,0,0,,Number of procedure occurrence records with invalid provider_id,,,,,,1
+613,0,0,,Number of procedure occurrence records with invalid visit_id,,,,,,1
+620,0,0,,Number of procedure occurrence records  by procedure occurrence start month,calendar month,,,,,1
+625,0,0,,Number of procedure_occurrence records by procedure_source_concept_id,procedure_source_concept_id,,,,,1
+624,0,0,,Number of distinct people with co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,num_people,num_cases,0
+691,0,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,,1
+700,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,,1
+701,0,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,,1
+702,0,0,,"Number of persons by drug exposure start month, by drug_concept_id",drug_concept_id,calendar month,,,,1
+703,1,0,,Number of distinct drug exposure concepts per person,,,,,,1
+704,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1
+705,0,0,,"Number of drug exposure records, by drug_concept_id by drug_type_concept_id",drug_concept_id,drug_type_concept_id,,,,1
+706,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1
+709,0,0,,Number of drug exposure records with invalid person_id,,,,,,1
+710,0,0,,Number of drug exposure records outside valid observation period,,,,,,1
+711,0,0,,Number of drug exposure records with end date < start date,,,,,,1
+712,0,0,,Number of drug exposure records with invalid provider_id,,,,,,1
+713,0,0,,Number of drug exposure records with invalid visit_id,,,,,,1
+715,1,0,,Distribution of days_supply by drug_concept_id,drug_concept_id,,,,,1
+716,1,0,,Distribution of refills by drug_concept_id,drug_concept_id,,,,,1
+717,1,0,,Distribution of quantity by drug_concept_id,drug_concept_id,,,,,1
+720,0,0,,Number of drug exposure records  by drug exposure start month,calendar month,,,,,1
+725,0,0,,Number of drug_exposure records by drug_source_concept_id,drug_source_concept_id,,,,,1
+724,0,0,,Number of distinct people with co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,num_people,num_cases,0
+791,0,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,,1
+800,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,,1
+801,0,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,,1
+802,0,0,,"Number of persons by observation occurrence start month, by observation_concept_id",observation_concept_id,calendar month,,,,1
+803,1,0,,Number of distinct observation occurrence concepts per person,,,,,,1
+804,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile",observation_concept_id,calendar year,gender_concept_id,age decile,,1
+805,0,0,,"Number of observation occurrence records, by observation_concept_id by observation_type_concept_id",observation_concept_id,observation_type_concept_id,,,,1
+806,1,0,,Distribution of age by observation_concept_id,observation_concept_id,gender_concept_id,,,,1
+807,0,0,,"Number of observation occurrence records, by observation_concept_id and unit_concept_id",observation_concept_id,unit_concept_id,,,,1
+809,0,0,,Number of observation records with invalid person_id,,,,,,1
+810,0,0,,Number of observation records outside valid observation period,,,,,,1
+812,0,0,,Number of observation records with invalid provider_id,,,,,,1
+813,0,0,,Number of observation records with invalid visit_id,,,,,,1
+814,0,0,,"Number of observation records with no value (numeric, string, or concept)",,,,,,1
+815,1,0,,"Distribution of numeric values, by observation_concept_id and unit_concept_id",,,,,,1
+820,0,0,,Number of observation records  by observation start month,calendar month,,,,,1
+822,0,0,,"Number of observation records, by observation_concept_id and value_as_concept_id",observation_concept_id,value_as_concept_id,,,,1
+823,0,0,,"Number of observation records, by observation_concept_id and qualifier_concept_id",observation_concept_id,qualifier_concept_id,,,,1
+826,0,0,,Number of observation records by value_as_concept_id,value_as_concept_id,,,,,1
+827,0,0,,Number of observation records by unit_concept_id,unit_as_concept_id,,,,,1
+825,0,0,,Number of observation records by observation_source_concept_id,observation_source_concept_id,,,,,1
+824,0,0,,Number of distinct people with co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,num_people,num_cases,0
+891,0,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,,1
+900,0,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,,1
+901,0,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,,1
+902,0,0,,"Number of persons by drug era start month, by drug_concept_id",drug_concept_id,calendar month,,,,1
+903,1,0,,Number of distinct drug era concepts per person,,,,,,1
+904,0,0,,"Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1
+906,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1
+907,1,0,,"Distribution of drug era length, by drug_concept_id",drug_concept_id,,,,,1
+908,0,0,,Number of drug eras without valid person,,,,,,1
+909,0,0,,Number of drug eras outside valid observation period,,,,,,1
+910,0,0,,Number of drug eras with end date < start date,,,,,,1
+920,0,0,,Number of drug era records  by drug era start month,calendar month,,,,,1
+1000,0,0,,"Number of persons with at least one condition era, by condition_concept_id",condition_concept_id,,,,,1
+1001,0,0,,"Number of condition era records, by condition_concept_id",condition_concept_id,,,,,1
+1002,0,0,,"Number of persons by condition era start month, by condition_concept_id",condition_concept_id,calendar month,,,,1
+1003,1,0,,Number of distinct condition era concepts per person,,,,,,1
+1004,0,0,,"Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1
+1006,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1
+1007,1,0,,"Distribution of condition era length, by condition_concept_id",condition_concept_id,,,,,1
+1008,0,0,,Number of condition eras without valid person,,,,,,1
+1009,0,0,,Number of condition eras outside valid observation period,,,,,,1
+1010,0,0,,Number of condition eras with end date < start date,,,,,,1
+1020,0,0,,Number of condition era records by condition era start month,calendar month,,,,,1
+1100,0,0,,Number of persons by location 3-digit zip,3-digit zip,,,,,1
+1101,0,0,,Number of persons by location state,state,,,,,1
+1102,0,0,,Number of care sites by location 3-digit zip,3-digit zip,,,,,1
+1103,0,0,,Number of care sites by location state,state,,,,,1
+1200,0,0,,Number of persons by place of service,place_of_service_concept_id,,,,,1
+1201,0,0,,Number of visits by place of service,place_of_service_concept_id,,,,,1
+1202,0,0,,Number of care sites by place of service,place_of_service_concept_id,,,,,1
+1203,0,0,,Number of visits by place of service discharge type,discharge_to_concept_id,,,,,1
+1406,1,0,,Length of payer plan (days) of first payer plan period by gender,gender_concept_id,,,,,1
+1407,1,0,,Length of payer plan (days) of first payer plan period by age decile,age_decile,,,,,1
+1408,0,0,,"Number of persons by length of payer plan period, in 30d increments",payer plan period length 30d increments,,,,,1
+1409,0,0,,Number of persons with continuous payer plan in each year,calendar year,,,,,1
+1410,0,0,,Number of persons with continuous payer plan in each month,calendar month,,,,,1
+1411,0,0,,Number of persons by payer plan period start month,calendar month,,,,,1
+1412,0,0,,Number of persons by payer plan period end month,calendar month,,,,,1
+1413,0,0,,Number of persons by number of payer plan periods,number of payer plan periods,,,,,1
+1414,0,0,,Number of persons with payer plan period before year-of-birth,,,,,,1
+1415,0,0,,Number of persons with payer plan period end < payer plan period start,,,,,,1
+1425,0,0,,Number of payer_plan_period records by payer_source_concept_id,payer_source_concept_id,,,,,1
+1500,0,1,,Number of drug cost records with invalid drug exposure id,,,,,,1
+1501,0,1,,Number of drug cost records with invalid payer plan period id,,,,,,1
+1502,1,1,paid_copay,"Distribution of paid copay, by drug_concept_id",drug_concept_id,,,,,1
+1503,1,1,paid_coinsurance,"Distribution of paid coinsurance, by drug_concept_id",drug_concept_id,,,,,1
+1504,1,1,paid_toward_deductible,"Distribution of paid toward deductible, by drug_concept_id",drug_concept_id,,,,,1
+1505,1,1,paid_by_payer,"Distribution of paid by payer, by drug_concept_id",drug_concept_id,,,,,1
+1506,1,1,paid_by_coordination_benefits,"Distribution of paid by coordination of benefit, by drug_concept_id",drug_concept_id,,,,,1
+1507,1,1,total_out_of_pocket,"Distribution of total out-of-pocket, by drug_concept_id",drug_concept_id,,,,,1
+1508,1,1,total_paid,"Distribution of total paid, by drug_concept_id",drug_concept_id,,,,,1
+1509,1,1,ingredient_cost,"Distribution of ingredient_cost, by drug_concept_id",drug_concept_id,,,,,1
+1510,1,1,dispensing_fee,"Distribution of dispensing fee, by drug_concept_id",drug_concept_id,,,,,1
+1511,1,1,average_wholesale_price,"Distribution of average wholesale price, by drug_concept_id",drug_concept_id,,,,,1
+1600,0,1,,Number of procedure cost records with invalid procedure occurrence id,,,,,,1
+1601,0,1,,Number of procedure cost records with invalid payer plan period id,,,,,,1
+1602,1,1,paid_copay,"Distribution of paid copay, by procedure_concept_id",procedure_concept_id,,,,,1
+1603,1,1,paid_coinsurance,"Distribution of paid coinsurance, by procedure_concept_id",procedure_concept_id,,,,,1
+1604,1,1,paid_toward_deductible,"Distribution of paid toward deductible, by procedure_concept_id",procedure_concept_id,,,,,1
+1605,1,1,paid_by_payer,"Distribution of paid by payer, by procedure_concept_id",procedure_concept_id,,,,,1
+1606,1,1,paid_by_coordination_benefits,"Distribution of paid by coordination of benefit, by procedure_concept_id",procedure_concept_id,,,,,1
+1607,1,1,total_out_of_pocket,"Distribution of total out-of-pocket, by procedure_concept_id",procedure_concept_id,,,,,1
+1608,1,1,total_paid,"Distribution of total paid, by procedure_concept_id",procedure_concept_id,,,,,1
+1610,0,1,,Number of records by revenue_code_concept_id,revenue_code_concept_id,,,,,1
+1700,0,0,,Number of records by cohort_concept_id,cohort_concept_id,,,,,1
+1701,0,0,,Number of records with cohort end date < cohort start date,,,,,,1
+1800,0,0,,"Number of persons with at least one measurement occurrence, by measurement_concept_id",measurement_concept_id,,,,,1
+1801,0,0,,"Number of measurement occurrence records, by measurement_concept_id",measurement_concept_id,,,,,1
+1802,0,0,,"Number of persons by measurement occurrence start month, by measurement_concept_id",measurement_concept_id,calendar month,,,,1
+1803,1,0,,Number of distinct mesurement occurrence concepts per person,,,,,,1
+1804,0,0,,"Number of persons with at least one mesurement  occurrence, by measurement_concept_id by calendar year by gender by age decile",measurement_concept_id,calendar year,gender_concept_id,age decile,,1
+1805,0,0,,"Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id",measurement_concept_id,measurement_type_concept_id,,,,1
+1806,1,0,,Distribution of age by measurement_concept_id,measurement_concept_id,gender_concept_id,,,,1
+1807,0,0,,"Number of measurement occurrence records, by measurement_concept_id and unit_concept_id",measurement_concept_id,unit_concept_id,,,,1
+1809,0,0,,Number of measurement records with invalid person_id,,,,,,1
+1810,0,0,,Number of measurement records outside valid observation period,,,,,,1
+1812,0,0,,Number of measurement records with invalid provider_id,,,,,,1
+1813,0,0,,Number of measurement records with invalid visit_id,,,,,,1
+1814,0,0,,"Number of measurement records with no value (numeric, string, or concept)",,,,,,1
+1815,1,0,,"Distribution of numeric values, by measurement_concept_id and unit_concept_id",,,,,,1
+1816,1,0,,"Distribution of low range, by measurement_concept_id and unit_concept_id",,,,,,1
+1817,1,0,,"Distribution of high range, by measurement_concept_id and unit_concept_id",,,,,,1
+1818,0,0,,"Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id",,,,,,1
+1820,0,0,,Number of measurement records  by measurement start month,calendar month,,,,,1
+1821,0,0,,Number of measurement records with no numeric value,,,,,,1
+1822,0,0,,"Number of measurement records, by measurement_concept_id and value_as_concept_id",measurement_concept_id,value_as_concept_id,,,,1
+1823,0,0,,"Number of measurement records, by measurement_concept_id and operator_concept_id",measurement_concept_id,operator_concept_id,,,,1
+1826,0,0,,Number of measurement records by value_as_concept_id,value_as_concept_id,,,,,1
+1827,0,0,,Number of measurement records by unit_concept_id,unit_as_concept_id,,,,,1
+1825,0,0,,Number of measurement records by measurement_source_concept_id,measurement_source_concept_id,,,,,1
+1824,0,0,,Number of distinct people with co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,num_people,num_cases,0
+1891,0,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,,1
+1900,0,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,,1
+2000,0,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,,1
+2001,0,0,,Number of patients with at least 1 Dx and 1 Proc,,,,,,1
+2002,0,0,,"Number of patients with at least 1 Meas, 1 Dx and 1 Rx",,,,,,1
+2003,0,0,,Number of patients with at least 1 Visit,,,,,,1
+2100,0,0,,"Number of persons with at least one device exposure, by device_concept_id",device_concept_id,,,,,1
+2101,0,0,,"Number of device exposure records, by device_concept_id",device_concept_id,,,,,1
+2102,0,0,,"Number of persons by device records  start month, by device_concept_id",device_concept_id,calendar month,,,,1
+2104,0,0,,"Number of persons with at least one device exposure, by device_concept_id by calendar year by gender by age decile",device_concept_id,calendar year,gender_concept_id,age decile,,1
+2105,0,0,,"Number of device exposure records, by device_concept_id by device_type_concept_id",device_concept_id,device_type_concept_id,,,,1
+2125,0,0,,Number of device_exposure records by device_source_concept_id,device_source_concept_id,,,,,1
+2200,0,0,,Number of persons with at least one note by  note_type_concept_id,note_type_concept_id,,,,,1
+2201,0,0,,"Number of note records, by note_type_concept_id",note_type_concept_id,,,,,1

--- a/inst/sql/sql_server/analyses/1824.sql
+++ b/inst/sql/sql_server/analyses/1824.sql
@@ -1,47 +1,40 @@
 -- 1824	
--- For each measurement concept, compute the top 15 co-occurring measurement concepts.
+-- For each measurement concept, find and rank the top 10 co-occurring measurement concepts.
 --
 
--- create unique person_id,measurement_concept_id pairs for people with at least 2 different (mapped) measurements.
-
---HINT DISTRIBUTE_ON_KEY(measurement_concept_id)
-select distinct person_id,measurement_concept_id
-  into #unique_pairs_1824
-  from @cdmDatabaseSchema.measurement
- where measurement_concept_id != 0
-   and person_id not in ( select person_id 
-                            from @cdmDatabaseSchema.measurement
-						   where measurement_concept_id != 0
-                           group by person_id
-                          having count(distinct measurement_concept_id) = 1 );
-
- -- Create ordered pairs of concept_ids, then count and rank them (measurement pairs must have at least 1000 distinct people) 
-
- --HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- Find all measurement_concept_id pairs, the number of people with these pairs, 
+-- and the number of times these pairs occur.
+with pairs as (
+select m1.measurement_concept_id measurement_concept_id_1,
+       m2.measurement_concept_id measurement_concept_id_2,
+       count(distinct m2.person_id) num_people,
+       count(*) num_cases
+  from @cdmDatabaseSchema.measurement m1
+  join @cdmDatabaseSchema.measurement m2
+    on m1.person_id = m2.person_id
+ where m1.measurement_concept_id != 0
+   and m2.measurement_concept_id != 0
+   and m1.measurement_concept_id != m2.measurement_concept_id
+ group by m1.measurement_concept_id, m2.measurement_concept_id
+), ranks as (
+-- Rank order the pairs by the number of people who have them and use
+-- the number of cases as a tie breaker
+select measurement_concept_id_1, 
+       measurement_concept_id_2, 
+	   num_people,
+	   num_cases,
+       row_number()over(partition by measurement_concept_id_1 order by num_people desc, num_cases desc) ranking
+  from pairs
+) 
 select 1824 as analysis_id,
-       cast(concept_id_1 as varchar(255)) as stratum_1,
-	   cast(concept_id_2 as varchar(255)) as stratum_2,
-	   cast(ranking      as varchar(255)) as stratum_3,
-	   cast(null         as varchar(255)) as stratum_4,
-       cast(null         as varchar(255)) as stratum_5,
-	   num_people        as count_value		
-  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1824
-  from (
-select concept_id_1, concept_id_2, num_people,
-       row_number()over(partition by concept_id_1 order by num_people desc) ranking
-  from (
-select t1.measurement_concept_id concept_id_1,
-       t2.measurement_concept_id concept_id_2,
-       count(distinct t1.person_id) num_people
-  from #unique_pairs_1824 t1,
-       #unique_pairs_1824 t2
- where t1.person_id               = t2.person_id
-   and t1.measurement_concept_id != t2.measurement_concept_id
- group by t1.measurement_concept_id,t2.measurement_concept_id
-having count(distinct t1.person_id) >= 1000 
-       ) tmp
-       ) tmp
- where ranking <= 15;
-
-truncate table #unique_pairs_1824;
-drop table #unique_pairs_1824;
+       cast(measurement_concept_id_1 as varchar(255)) as stratum_1,
+	   cast(measurement_concept_id_2 as varchar(255)) as stratum_2,
+	   cast(ranking                  as varchar(255)) as stratum_3,
+	   cast(num_people               as varchar(255)) as stratum_4,
+       cast(num_cases                as varchar(255)) as stratum_5,
+	   num_people                    as count_value		
+  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1824 
+  from ranks 
+ where ranking <= 10
+;

--- a/inst/sql/sql_server/analyses/424.sql
+++ b/inst/sql/sql_server/analyses/424.sql
@@ -1,47 +1,42 @@
 -- 424
--- For each condition concept, compute the top 15 co-occurring condition concepts.
+-- For each condition concept, find and rank the top 10 co-occurring condition concepts.
 --
 
--- create unique person_id,condition_concept_id pairs for people with at least 2 different (mapped) conditions.
-
---HINT DISTRIBUTE_ON_KEY(condition_concept_id)
-select distinct person_id,condition_concept_id
-  into #unique_pairs_424
-  from @cdmDatabaseSchema.condition_occurrence
- where condition_concept_id != 0
-   and person_id not in ( select person_id 
-                            from @cdmDatabaseSchema.condition_occurrence
-						   where condition_concept_id != 0
-                           group by person_id
-                          having count(distinct condition_concept_id) = 1 );
-
--- Create ordered pairs of concept_ids, then count and rank them (condition pairs must have at least 1000 distinct people)
-
- --HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- Find all condition_concept_id pairs, the number of people with these pairs, 
+-- and the number of times these pairs occur.
+with pairs as (
+select c1.condition_concept_id condition_concept_id_1,
+       c2.condition_concept_id condition_concept_id_2,
+       count(distinct c2.person_id) num_people,
+       count(*) num_cases
+  from @cdmDatabaseSchema.condition_occurrence c1
+  join @cdmDatabaseSchema.condition_occurrence c2
+    on c1.person_id = c2.person_id
+ where c1.condition_concept_id != 0
+   and c2.condition_concept_id != 0
+   and c1.condition_concept_id != c2.condition_concept_id
+ group by c1.condition_concept_id, c2.condition_concept_id
+), ranks as (
+-- Rank order the pairs by the number of people who have them and use
+-- the number of cases as a tie breaker
+select condition_concept_id_1, 
+       condition_concept_id_2, 
+	   num_people,
+	   num_cases,
+       row_number()over(partition by condition_concept_id_1 order by num_people desc, num_cases desc) ranking
+  from pairs
+) 
 select 424 as analysis_id,
-       cast(concept_id_1 as varchar(255)) as stratum_1,
-	   cast(concept_id_2 as varchar(255)) as stratum_2,
-	   cast(ranking      as varchar(255)) as stratum_3,
-	   cast(null         as varchar(255)) as stratum_4,
-       cast(null         as varchar(255)) as stratum_5,
-	   num_people        as count_value		
-  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_424
-  from (
-select concept_id_1, concept_id_2, num_people,
-       row_number()over(partition by concept_id_1 order by num_people desc) ranking
-  from (
-select t1.condition_concept_id concept_id_1,
-       t2.condition_concept_id concept_id_2,
-       count(distinct t1.person_id) num_people
-  from #unique_pairs_424 t1,
-       #unique_pairs_424 t2
- where t1.person_id             = t2.person_id
-   and t1.condition_concept_id != t2.condition_concept_id
- group by t1.condition_concept_id,t2.condition_concept_id
-having count(distinct t1.person_id) >= 1000 
-       ) tmp
-       ) tmp
- where ranking <= 15;
+       cast(condition_concept_id_1 as varchar(255)) as stratum_1,
+	   cast(condition_concept_id_2 as varchar(255)) as stratum_2,
+	   cast(ranking                as varchar(255)) as stratum_3,
+	   cast(num_people             as varchar(255)) as stratum_4,
+       cast(num_cases              as varchar(255)) as stratum_5,
+	   num_people                  as count_value		
+  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_424 
+  from ranks 
+ where ranking <= 10
+;
 
-truncate table #unique_pairs_424;
-drop table #unique_pairs_424;
+

--- a/inst/sql/sql_server/analyses/424.sql
+++ b/inst/sql/sql_server/analyses/424.sql
@@ -38,5 +38,3 @@ select 424 as analysis_id,
   from ranks 
  where ranking <= 10
 ;
-
-

--- a/inst/sql/sql_server/analyses/624.sql
+++ b/inst/sql/sql_server/analyses/624.sql
@@ -1,47 +1,40 @@
 -- 624
--- For each procedure concept, compute the top 15 co-occurring procedure concepts.
+-- For each procedure concept, find and rank the top 10 co-occurring procedure concepts.
 --
 
--- create unique person_id,procedure_concept_id pairs for people with at least 2 different (mapped) procedures.
-
---HINT DISTRIBUTE_ON_KEY(procedure_concept_id)
-select distinct person_id,procedure_concept_id
-  into #unique_pairs_624
-  from @cdmDatabaseSchema.procedure_occurrence
- where procedure_concept_id != 0
-   and person_id not in ( select person_id 
-                            from @cdmDatabaseSchema.procedure_occurrence
-						   where procedure_concept_id != 0
-                           group by person_id
-                          having count(distinct procedure_concept_id) = 1 );
-
--- Create ordered pairs of concept_ids, then count and rank them (procedure pairs must have at least 1000 distinct people)
-
- --HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- Find all procedure_concept_id pairs, the number of people with these pairs, 
+-- and the number of times these pairs occur.
+with pairs as (
+select p1.procedure_concept_id procedure_concept_id_1,
+       p2.procedure_concept_id procedure_concept_id_2,
+       count(distinct p2.person_id) num_people,
+       count(*) num_cases
+  from @cdmDatabaseSchema.procedure_occurrence p1
+  join @cdmDatabaseSchema.procedure_occurrence p2
+    on p1.person_id = p2.person_id
+ where p1.procedure_concept_id != 0
+   and p2.procedure_concept_id != 0
+   and p1.procedure_concept_id != p2.procedure_concept_id
+ group by p1.procedure_concept_id, p2.procedure_concept_id
+), ranks as (
+-- Rank order the pairs by the number of people who have them and use
+-- the number of cases as a tie breaker
+select procedure_concept_id_1, 
+       procedure_concept_id_2, 
+	   num_people,
+	   num_cases,
+       row_number()over(partition by procedure_concept_id_1 order by num_people desc, num_cases desc) ranking
+  from pairs
+) 
 select 624 as analysis_id,
-       cast(concept_id_1 as varchar(255)) as stratum_1,
-	   cast(concept_id_2 as varchar(255)) as stratum_2,
-	   cast(ranking      as varchar(255)) as stratum_3,
-	   cast(null         as varchar(255)) as stratum_4,
-       cast(null         as varchar(255)) as stratum_5,
-	   num_people        as count_value		
-  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_624
-  from (
-select concept_id_1, concept_id_2, num_people,
-       row_number()over(partition by concept_id_1 order by num_people desc) ranking
-  from (
-select t1.procedure_concept_id concept_id_1,
-       t2.procedure_concept_id concept_id_2,
-       count(distinct t1.person_id) num_people
-  from #unique_pairs_624 t1,
-       #unique_pairs_624 t2
- where t1.person_id             = t2.person_id
-   and t1.procedure_concept_id != t2.procedure_concept_id
- group by t1.procedure_concept_id,t2.procedure_concept_id
-having count(distinct t1.person_id) >= 1000 
-       ) tmp
-       ) tmp
- where ranking <= 15;
-
-truncate table #unique_pairs_624;
-drop table #unique_pairs_624;
+       cast(procedure_concept_id_1 as varchar(255)) as stratum_1,
+	   cast(procedure_concept_id_2 as varchar(255)) as stratum_2,
+	   cast(ranking                as varchar(255)) as stratum_3,
+	   cast(num_people             as varchar(255)) as stratum_4,
+       cast(num_cases              as varchar(255)) as stratum_5,
+	   num_people                  as count_value		
+  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_624 
+  from ranks 
+ where ranking <= 10
+;

--- a/inst/sql/sql_server/analyses/724.sql
+++ b/inst/sql/sql_server/analyses/724.sql
@@ -1,47 +1,41 @@
 -- 724
--- For each drug concept, compute the top 15 co-occurring drug concepts.
+-- For each drug concept, find and rank the top 10 co-occurring drug concepts.
 --
 
--- create unique person_id, drug_concept_id pairs for people with at least 2 different (mapped) drug exposures.
-
---HINT DISTRIBUTE_ON_KEY(drug_concept_id)
-select distinct person_id,drug_concept_id
-  into #unique_pairs_724
-  from @cdmDatabaseSchema.drug_exposure
- where drug_concept_id != 0
-   and person_id not in ( select person_id 
-                            from @cdmDatabaseSchema.drug_exposure
-						   where drug_concept_id != 0
-                           group by person_id
-                          having count(distinct drug_concept_id) = 1 );
-						  
--- Create ordered pairs of concept_ids, then count and rank them (drug pairs must have at least 1000 distinct people)
- 
---HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- Find all drug_concept_id pairs, the number of people with these pairs, 
+-- and the number of times these pairs occur.
+with pairs as (
+select d1.drug_concept_id drug_concept_id_1,
+       d2.drug_concept_id drug_concept_id_2,
+       count(distinct d2.person_id) num_people,
+       count(*) num_cases
+  from @cdmDatabaseSchema.drug_exposure d1
+  join @cdmDatabaseSchema.drug_exposure d2
+    on d1.person_id = d2.person_id
+ where d1.drug_concept_id != 0
+   and d2.drug_concept_id != 0
+   and d1.drug_concept_id != d2.drug_concept_id
+ group by d1.drug_concept_id, d2.drug_concept_id
+), ranks as (
+-- Rank order the pairs by the number of people who have them and use
+-- the number of cases as a tie breaker
+select drug_concept_id_1, 
+       drug_concept_id_2, 
+	   num_people,
+	   num_cases,
+       row_number()over(partition by drug_concept_id_1 order by num_people desc, num_cases desc) ranking
+  from pairs
+) 
 select 724 as analysis_id,
-       cast(concept_id_1 as varchar(255)) as stratum_1,
-	   cast(concept_id_2 as varchar(255)) as stratum_2,
-	   cast(ranking      as varchar(255)) as stratum_3,
-	   cast(null         as varchar(255)) as stratum_4,
-       cast(null         as varchar(255)) as stratum_5,
-	   num_people        as count_value		
-  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_724
-  from (
-select concept_id_1, concept_id_2, num_people,
-       row_number()over(partition by concept_id_1 order by num_people desc) ranking
-  from (
-select t1.drug_concept_id concept_id_1,
-       t2.drug_concept_id concept_id_2,
-       count(distinct t1.person_id) num_people
-  from #unique_pairs_724 t1,
-       #unique_pairs_724 t2
- where t1.person_id        = t2.person_id
-   and t1.drug_concept_id != t2.drug_concept_id
- group by t1.drug_concept_id,t2.drug_concept_id
-having count(distinct t1.person_id) >= 1000 
-       ) tmp
-       ) tmp
- where ranking <= 15;
+       cast(drug_concept_id_1 as varchar(255)) as stratum_1,
+	   cast(drug_concept_id_2 as varchar(255)) as stratum_2,
+	   cast(ranking           as varchar(255)) as stratum_3,
+	   cast(num_people        as varchar(255)) as stratum_4,
+       cast(num_cases         as varchar(255)) as stratum_5,
+	   num_people             as count_value		
+  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_724 
+  from ranks 
+ where ranking <= 10
+;
 
-truncate table #unique_pairs_724;
-drop table #unique_pairs_724;

--- a/inst/sql/sql_server/analyses/824.sql
+++ b/inst/sql/sql_server/analyses/824.sql
@@ -1,47 +1,40 @@
 -- 824
--- For each observation concept, compute the top 15 co-occurring observation concepts.
+-- For each observation concept, find and rank the top 10 co-occurring observation concepts.
 --
 
--- create unique person_id,observation_concept_id pairs for people with at least 2 different (mapped) observations.
-
---HINT DISTRIBUTE_ON_KEY(observation_concept_id)
-select distinct person_id,observation_concept_id
-  into #unique_pairs_824
-  from @cdmDatabaseSchema.observation
- where observation_concept_id != 0
-   and person_id not in ( select person_id 
-                            from @cdmDatabaseSchema.observation
-						   where observation_concept_id != 0
-                           group by person_id
-                          having count(distinct observation_concept_id) = 1 );
-
- -- Create ordered pairs of concept_ids, then count and rank them (observation pairs must have at least 1000 distinct people) 
- 
- --HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- HINT DISTRIBUTE_ON_KEY(stratum_1)
+-- Find all observation_concept_id pairs, the number of people with these pairs, 
+-- and the number of times these pairs occur.
+with pairs as (
+select o1.observation_concept_id observation_concept_id_1,
+       o2.observation_concept_id observation_concept_id_2,
+       count(distinct o2.person_id) num_people,
+       count(*) num_cases
+  from @cdmDatabaseSchema.observation o1
+  join @cdmDatabaseSchema.observation o2
+    on o1.person_id = o2.person_id
+ where o1.observation_concept_id != 0
+   and o2.observation_concept_id != 0
+   and o1.observation_concept_id != o2.observation_concept_id
+ group by o1.observation_concept_id, o2.observation_concept_id
+), ranks as (
+-- Rank order the pairs by the number of people who have them and use
+-- the number of cases as a tie breaker
+select observation_concept_id_1, 
+       observation_concept_id_2, 
+	   num_people,
+	   num_cases,
+       row_number()over(partition by observation_concept_id_1 order by num_people desc, num_cases desc) ranking
+  from pairs
+) 
 select 824 as analysis_id,
-       cast(concept_id_1 as varchar(255)) as stratum_1,
-	   cast(concept_id_2 as varchar(255)) as stratum_2,
-	   cast(ranking      as varchar(255)) as stratum_3,
-	   cast(null         as varchar(255)) as stratum_4,
-       cast(null         as varchar(255)) as stratum_5,
-	   num_people        as count_value		
-  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_824
-  from (
-select concept_id_1, concept_id_2, num_people,
-       row_number()over(partition by concept_id_1 order by num_people desc) ranking
-  from (
-select t1.observation_concept_id concept_id_1,
-       t2.observation_concept_id concept_id_2,
-       count(distinct t1.person_id) num_people
-  from #unique_pairs_824 t1,
-       #unique_pairs_824 t2
- where t1.person_id               = t2.person_id
-   and t1.observation_concept_id != t2.observation_concept_id
- group by t1.observation_concept_id,t2.observation_concept_id
-having count(distinct t1.person_id) >= 1000 
-       ) tmp
-       ) tmp
- where ranking <= 15;
-
-truncate table #unique_pairs_824;
-drop table #unique_pairs_824;
+       cast(observation_concept_id_1 as varchar(255)) as stratum_1,
+	   cast(observation_concept_id_2 as varchar(255)) as stratum_2,
+	   cast(ranking                  as varchar(255)) as stratum_3,
+	   cast(num_people               as varchar(255)) as stratum_4,
+       cast(num_cases                as varchar(255)) as stratum_5,
+	   num_people                    as count_value		
+  into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_824 
+  from ranks 
+ where ranking <= 10
+;

--- a/man/achilles.Rd
+++ b/man/achilles.Rd
@@ -26,7 +26,8 @@ achilles(
   sqlOnly = FALSE,
   outputFolder = "output",
   verboseMode = TRUE,
-  optimizeAtlasCache = FALSE
+  optimizeAtlasCache = FALSE,
+  defaultAnalysesOnly = TRUE
 )
 }
 \arguments{
@@ -78,6 +79,8 @@ If not specified, all analyses will be executed. Use \code{\link{getAnalysisDeta
 \item{verboseMode}{Boolean to determine if the console will show all execution steps. Default = TRUE}
 
 \item{optimizeAtlasCache}{Boolean to determine if the atlas cache has to be optimized. Default = FALSE}
+
+\item{defaultAnalysesOnly}{Boolean to determine if only default analyses should be run. Including non-default analyses is substantially more resource intensive.  Default = TRUE}
 }
 \value{
 An object of type \code{achillesResults} containing details for connecting to the database containing the results


### PR DESCRIPTION
The co-occurrence queries have been optimized to address issue #425 
The before and after is below (against a MDCD db):

Original:

```
Analysis     Time
---------    -----
424          (1.1 hours)
624          (41 mins)
724          (18 mins)
824          (4 mins)
1824         (9 mins)

TOTAL: ~2hr 20 min

```
```
Analysis     Time
---------    -----
424          (40 mins)
624          (10 mins)
724          (6 mins)
824          (20 mins)
1824         (2 mins)

TOTAL: ~1hr 18 minutes

```
Even with the optimizations, these analyses will run more slowly on dbs larger than MDCD, therefore, the main Achilles function was modified to accept a defaultAnalysesOnly parameter to indicate whether or not you want to run the co-occurrence queries. By default, they will not be run.  This was achieved by adding an additional column to achilles_analysis_details.csv.
