### PR TITLE
Fixes #473 by converting dates to 8 digit integers

### DIFF
--- a/inst/sql/sql_server/analyses/109.sql
+++ b/inst/sql/sql_server/analyses/109.sql
@@ -4,8 +4,8 @@
 --HINT DISTRIBUTE_ON_KEY(obs_year)
 SELECT DISTINCT 
   YEAR(observation_period_start_date) AS obs_year,
-  DATEFROMPARTS(YEAR(observation_period_start_date), 1, 1) AS obs_year_start,
-  DATEFROMPARTS(YEAR(observation_period_start_date), 12, 31) AS obs_year_end
+  (YEAR(observation_period_start_date)*100 + 1)*100 + 1 AS obs_year_start,
+  (YEAR(observation_period_start_date)*100 + 12)*100 + 31 AS obs_year_end
 INTO
   #temp_dates_109
 FROM @cdmDatabaseSchema.observation_period
@@ -13,17 +13,17 @@ FROM @cdmDatabaseSchema.observation_period
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 SELECT 
-  109 AS analysis_id,  
+	109 AS analysis_id,  
 	CAST(obs_year AS VARCHAR(255)) AS stratum_1,
-	cast(null as varchar(255)) as stratum_2, cast(null as varchar(255)) as stratum_3, cast(null as varchar(255)) as stratum_4, cast(null as varchar(255)) as stratum_5,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2, CAST(NULL AS VARCHAR(255)) AS stratum_3, CAST(NULL AS VARCHAR(255)) AS stratum_4, CAST(NULL AS VARCHAR(255)) AS stratum_5,
 	COUNT_BIG(DISTINCT person_id) AS count_value
-into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_109
-FROM @cdmDatabaseSchema.observation_period,
-	#temp_dates_109
-WHERE  
-		observation_period_start_date <= obs_year_start
-	AND 
-		observation_period_end_date >= obs_year_end
+INTO @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_109
+FROM @cdmDatabaseSchema.observation_period
+CROSS JOIN #temp_dates_109
+WHERE
+	(YEAR(observation_period_start_date)*100 + MONTH(observation_period_start_date))*100 + DAY(observation_period_start_date) <= obs_year_start
+AND
+	(YEAR(observation_period_end_date)*100 + MONTH(observation_period_end_date))*100 + DAY(observation_period_end_date) >= obs_year_end
 GROUP BY 
 	obs_year
 ;


### PR DESCRIPTION
By treating a date string, "YYYYMMDD", as an 8 digit integer, we can perform this analysis without worrying about functions.
Tested successfully on both Oracle and Redshift databases.  
