### PR TITLE
Big query does not allow to use join without a condition that is an equality of fields from both sides of the join

### DIFF
--- a/inst/sql/sql_server/analyses/117.sql
+++ b/inst/sql/sql_server/analyses/117.sql
@@ -14,8 +14,11 @@ SELECT
 	COALESCE(COUNT_BIG(distinct op1.PERSON_ID),0) as count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_117	
 FROM date_keys t1
-left join @cdmDatabaseSchema.observation_period op1
-on year(op1.observation_period_start_date)*100 + month(op1.observation_period_start_date) <= t1.obs_month
-and year(op1.observation_period_end_date)*100 + month(op1.observation_period_end_date) >= t1.obs_month
+left join
+  (select t2.obs_month, op2.*
+    from @cdmDatabaseSchema.observation_period op2, date_keys t2
+    where year(op2.observation_period_start_date)*100 + month(op2.observation_period_start_date) <= t2.obs_month
+    and year(op2.observation_period_end_date)*100 + month(op2.observation_period_end_date) >= t2.obs_month
+  ) op1 on op1.obs_month = t1.obs_month
 group by t1.obs_month
 having COALESCE(COUNT_BIG(distinct op1.PERSON_ID),0) > 0;


### PR DESCRIPTION
fixes https://github.com/OHDSI/Achilles/issues/532

I've tried several different changes of sql code and this modification has better or similar execution plan and better execution time (tested on postgres, ms sql, netezza and hive)