### PR TITLE
Big query, hive and impala use special constructions to emulation "intersect" behaviour and these constructions need only column name without table name after "select distinct"

### DIFF
--- a/inst/sql/sql_server/analyses/2000.sql
+++ b/inst/sql/sql_server/analyses/2000.sql
@@ -1,44 +1,50 @@
 -- 2000	patients with at least 1 Dx and 1 Rx
 
-SELECT 
+SELECT
 	2000 AS analysis_id,
 	CAST(NULL AS VARCHAR(255)) AS stratum_1,
 	CAST(NULL AS VARCHAR(255)) AS stratum_2,
 	CAST(NULL AS VARCHAR(255)) AS stratum_3,
 	CAST(NULL AS VARCHAR(255)) AS stratum_4,
 	CAST(NULL AS VARCHAR(255)) AS stratum_5,
-	CAST(a.cnt AS BIGINT) AS count_value
-INTO 
+	CAST(d.cnt AS BIGINT) AS count_value
+INTO
 	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2000
 FROM (
 SELECT COUNT_BIG(*) cnt
 FROM (
-	SELECT 
-		DISTINCT co.person_id
-	FROM 
-		@cdmDatabaseSchema.condition_occurrence co
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		co.person_id = op.person_id
-	AND 
-		co.condition_start_date >= op.observation_period_start_date
-	AND 
-		co.condition_start_date <= op.observation_period_end_date		
+  SELECT DISTINCT person_id
+  FROM (
+    SELECT
+      co.person_id
+    FROM
+      @cdmDatabaseSchema.condition_occurrence co
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      co.person_id = op.person_id
+    AND
+      co.condition_start_date >= op.observation_period_start_date
+    AND
+      co.condition_start_date <= op.observation_period_end_date
+    ) a
 
 	INTERSECT
-	
-	SELECT 
-		DISTINCT de.person_id
-	FROM 
-		@cdmDatabaseSchema.drug_exposure de
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		de.person_id = op.person_id
-	AND 
-		de.drug_exposure_start_date >= op.observation_period_start_date
-	AND 
-		de.drug_exposure_start_date <= op.observation_period_end_date		
-	) b
-) a;
+
+	SELECT DISTINCT person_id
+  FROM (
+    SELECT
+      de.person_id
+    FROM
+      @cdmDatabaseSchema.drug_exposure de
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      de.person_id = op.person_id
+    AND
+      de.drug_exposure_start_date >= op.observation_period_start_date
+    AND
+      de.drug_exposure_start_date <= op.observation_period_end_date
+    ) b
+	) c
+) d;

--- a/inst/sql/sql_server/analyses/2001.sql
+++ b/inst/sql/sql_server/analyses/2001.sql
@@ -8,38 +8,44 @@ SELECT
 	CAST(NULL AS VARCHAR(255)) AS stratum_3,
 	CAST(NULL AS VARCHAR(255)) AS stratum_4,
 	CAST(NULL AS VARCHAR(255)) AS stratum_5,
-	CAST(a.cnt AS BIGINT) AS count_value
+	CAST(d.cnt AS BIGINT) AS count_value
 INTO 
 	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2001
 FROM (
 SELECT COUNT_BIG(*) cnt
 FROM (
-	SELECT 
-		DISTINCT co.person_id
-	FROM 
-		@cdmDatabaseSchema.condition_occurrence co
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		co.person_id = op.person_id
-	AND 
-		co.condition_start_date >= op.observation_period_start_date
-	AND 
-		co.condition_start_date <= op.observation_period_end_date		
+  SELECT DISTINCT person_id
+	FROM (
+    SELECT
+      co.person_id
+    FROM
+      @cdmDatabaseSchema.condition_occurrence co
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      co.person_id = op.person_id
+    AND
+      co.condition_start_date >= op.observation_period_start_date
+    AND
+      co.condition_start_date <= op.observation_period_end_date
+  ) a
 
 	INTERSECT
 	
-	SELECT 
-		DISTINCT po.person_id
-	FROM 
-		@cdmDatabaseSchema.procedure_occurrence po
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		po.person_id = op.person_id
-	AND 
-		po.procedure_date >= op.observation_period_start_date
-	AND 
-		po.procedure_date <= op.observation_period_end_date		
-	) b
-) a;
+	SELECT DISTINCT person_id
+	FROM (
+    SELECT
+      po.person_id
+    FROM
+      @cdmDatabaseSchema.procedure_occurrence po
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      po.person_id = op.person_id
+    AND
+      po.procedure_date >= op.observation_period_start_date
+    AND
+      po.procedure_date <= op.observation_period_end_date
+    ) b
+	) c
+) d;

--- a/inst/sql/sql_server/analyses/2002.sql
+++ b/inst/sql/sql_server/analyses/2002.sql
@@ -8,53 +8,62 @@ SELECT
 	CAST(NULL AS VARCHAR(255)) AS stratum_3,
 	CAST(NULL AS VARCHAR(255)) AS stratum_4,
 	CAST(NULL AS VARCHAR(255)) AS stratum_5,
-	CAST(a.cnt AS BIGINT) AS count_value
+	CAST(e.cnt AS BIGINT) AS count_value
 INTO 
 	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2002
 FROM (
 SELECT COUNT_BIG(*) cnt
 FROM (
-	SELECT 
-		DISTINCT m.person_id
-	FROM 
-		@cdmDatabaseSchema.measurement m
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		m.person_id = op.person_id
-	AND 
-		m.measurement_date >= op.observation_period_start_date
-	AND 
-		m.measurement_date <= op.observation_period_end_date		
+	SELECT DISTINCT person_id
+	FROM (
+    SELECT
+      m.person_id
+    FROM
+      @cdmDatabaseSchema.measurement m
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      m.person_id = op.person_id
+    AND
+      m.measurement_date >= op.observation_period_start_date
+    AND
+      m.measurement_date <= op.observation_period_end_date
+    ) a
 
 	INTERSECT
 
-	SELECT 
-		DISTINCT co.person_id
-	FROM 
-		@cdmDatabaseSchema.condition_occurrence co
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		co.person_id = op.person_id
-	AND 
-		co.condition_start_date >= op.observation_period_start_date
-	AND 
-		co.condition_start_date <= op.observation_period_end_date		
+	SELECT DISTINCT person_id
+	FROM (
+    SELECT
+      co.person_id
+    FROM
+      @cdmDatabaseSchema.condition_occurrence co
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      co.person_id = op.person_id
+    AND
+      co.condition_start_date >= op.observation_period_start_date
+    AND
+      co.condition_start_date <= op.observation_period_end_date
+    ) b
 
 	INTERSECT
 
-	SELECT 
-		DISTINCT de.person_id
-	FROM 
-		@cdmDatabaseSchema.drug_exposure de
-	JOIN 
-		@cdmDatabaseSchema.observation_period op 
-	ON 
-		de.person_id = op.person_id
-	AND 
-		de.drug_exposure_start_date >= op.observation_period_start_date
-	AND 
-		de.drug_exposure_start_date <= op.observation_period_end_date		
-	) b
-) a;
+	SELECT DISTINCT person_id
+	FROM (
+    SELECT
+      de.person_id
+    FROM
+      @cdmDatabaseSchema.drug_exposure de
+    JOIN
+      @cdmDatabaseSchema.observation_period op
+    ON
+      de.person_id = op.person_id
+    AND
+      de.drug_exposure_start_date >= op.observation_period_start_date
+    AND
+      de.drug_exposure_start_date <= op.observation_period_end_date
+    ) c
+	) d
+) e;


### PR DESCRIPTION
fixes https://github.com/OHDSI/Achilles/issues/556

execution plans for postgresql, ms sql, impala, netezza and hive are almost the same
