### PR TITLE
Changed 'not in' logic in analysis 11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
   person("Martijn", "Schuemie", email = "schuemie@ohdsi.org", role = c("aut")),
   person("Vojtech", "Huser", role = c("aut")),
   person("Chris", "Knoll", role = c("aut")),
-  person("Ajit", "Londhe", email = "alondhe@amgen.com", role = c("aut")),
+  person("Ajit", "Londhe", email = "londhe@ohdsi.org", role = c("aut")),
   person("Taha", "Abdul-Basser", role = c("aut")),
   person("Anthony", "Molinaro", role = c("aut")),
   person("Observational Health Data Science and Informatics", role = c("cph"))

--- a/inst/sql/sql_server/analyses/11.sql
+++ b/inst/sql/sql_server/analyses/11.sql
@@ -2,10 +2,15 @@
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 select 11 as analysis_id,  CAST(year_of_birth AS VARCHAR(255)) as stratum_1,
-  CAST(gender_concept_id AS VARCHAR(255)) as stratum_2,
+  CAST(P.gender_concept_id AS VARCHAR(255)) as stratum_2,
   cast(null as varchar(255)) as stratum_3, cast(null as varchar(255)) as stratum_4, cast(null as varchar(255)) as stratum_5,
-  COUNT_BIG(distinct person_id) as count_value
+  COUNT_BIG(distinct P.person_id) as count_value
 into @scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_11
-from @cdmDatabaseSchema.person
-where person_id not in (select person_id from @cdmDatabaseSchema.death)
-group by YEAR_OF_BIRTH, gender_concept_id;
+from @cdmDatabaseSchema.person P
+where not exists
+(
+  select 1
+  from @cdmDatabaseSchema.death D
+  where P.person_id = D.person_id
+)
+group by P.YEAR_OF_BIRTH, P.gender_concept_id;

--- a/inst/sql/sql_server/analyses/11.sql
+++ b/inst/sql/sql_server/analyses/11.sql
@@ -1,7 +1,7 @@
 -- 11	Number of non-deceased persons by year of birth and by gender
 
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
-select 11 as analysis_id,  CAST(year_of_birth AS VARCHAR(255)) as stratum_1,
+select 11 as analysis_id,  CAST(P.year_of_birth AS VARCHAR(255)) as stratum_1,
   CAST(P.gender_concept_id AS VARCHAR(255)) as stratum_2,
   cast(null as varchar(255)) as stratum_3, cast(null as varchar(255)) as stratum_4, cast(null as varchar(255)) as stratum_5,
   COUNT_BIG(distinct P.person_id) as count_value


### PR DESCRIPTION
 Changed 'not in' logic in analysis 11 to use not exists, which is better for Spark performance. Also updated my email address. 