### PR TITLE
Fixes #582

### DIFF
--- a/inst/sql/sql_server/analyses/109.sql
+++ b/inst/sql/sql_server/analyses/109.sql
@@ -6,7 +6,7 @@ with century as (select '19' num union select '20' num),
 tens as (select '0' num union select '1' num union select '2' num union select '3' num union select '4' num union select '5' num union select '6' num union select '7' num union select '8' num union select '9' num),
 ones as (select '0' num union select '1' num union select '2' num union select '3' num union select '4' num union select '5' num union select '6' num union select '7' num union select '8' num union select '9' num),
 months as (select '01' as num union select '02' num union select '03' num union select '04' num union select '05' num union select '06' num union select '07' num union select '08' num union select '09' num union select '10' num union select '11' num union select '12' num),
-date_keys as (select cast(concat(century.num, tens.num, ones.num,months.num) as int) obs_month from century cross join tens cross join ones cross join months),
+date_keys as (select concat(century.num, tens.num, ones.num,months.num)  obs_month from century cross join tens cross join ones cross join months),
 -- From date_keys, we just need each year and the first and last day of each year
 ymd as (
 select cast(substring(obs_month,1,4) as integer)      as obs_year,


### PR DESCRIPTION
Casting to integer and then performing substring was breaking on APS (and perhaps other platforms).  Redshift seems to handle the implicit type conversion without a problem, nonetheless, it doesn't make much sense to cast a string to an integer only to later use it with string functions.  The call to cast was removed.  Tested successfully against Redshift and APS.