### PR TITLE
Analysis to report proportion of records with "no value" in Measurement, stratified by measurement_concept_id

### DIFF
--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -271,6 +271,7 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 1830,0,0,,Number of visit_detail records inside a valid observation period,,,,,,1,Observation Period
 1831,0,0,,Proportion of people with at least one measurement record outside a valid observation period,Proportion,Number of people with a measurement record outside a valid observation period,Number of people in measurement,,,1,Observation Period
 1832,0,0,,Proportion of measurement records outside a valid observation period,Proportion,Number of records in measurement outside a valid observation period,Number of measurement records,,,1,Observation Period
+1833,0,0,,Proportion of measurement records inside a valid observation period and without a value,measurement_concept_id,Number of measurement records with no value for the given measurement_concept_id,proportion,,,1,Measurement
 1891,0,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,,1,Measurement
 1900,0,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,,1,Completeness
 2000,0,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,,1,Completeness

--- a/inst/sql/sql_server/analyses/1833.sql
+++ b/inst/sql/sql_server/analyses/1833.sql
@@ -1,0 +1,34 @@
+-- 1833	Proportion of measurement records with a valid observation period, but no value; stratified by measurement_concept_id
+--
+-- stratum_1:   measurement_concept_id
+-- stratum_2:   Number of measurement records with no value for the given measurement_concept_id
+-- stratum_3:   Proportion == stratum_2/count_value
+-- count_value: Number of measurement records for the given measurement_concept_id
+--
+
+SELECT 
+	1833 AS analysis_id,
+	m.measurement_concept_id AS stratum_1,
+	CAST(SUM(CASE WHEN m.value_as_number IS NULL 
+	          AND COALESCE(m.value_as_concept_id,0) = 0 
+	    THEN 1 ELSE 0 END) AS VARCHAR(255))  AS stratum_2,
+	CAST(CAST(1.0*SUM(CASE WHEN m.value_as_number IS NULL AND COALESCE(m.value_as_concept_id,0) = 0 
+	                  THEN 1 ELSE 0 END)/GREATEST(1,count(*)) AS NUMERIC(7,6)) AS VARCHAR(255)) AS stratum_3, 
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT(*) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1833
+FROM 
+	@cdmDatabaseSchema.measurement m
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	m.person_id = op.person_id
+AND 
+	m.measurement_date >= op.observation_period_start_date
+AND 
+	m.measurement_date <= op.observation_period_end_date
+GROUP BY 
+	m.measurement_concept_id
+;


### PR DESCRIPTION
NB: For the purposes of this analysis, we are defining a measurement record as "not having a value" if both of the following conditions are satisfied:

- value_as_number is null
- value_as_concept_id is null or 0 (expressed in SQL via coalesce())

