### PR TITLE
added reports for new condition_occurrence fields

### DIFF
--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -65,6 +65,9 @@ ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STR
 411,0,0,,Number of condition occurrence records with end date < start date,,,,,,1,Condition Occurrence
 412,0,0,,Number of condition occurrence records with invalid provider_id,,,,,,1,Condition Occurrence
 413,0,0,,Number of condition occurrence records with invalid visit_id,,,,,,1,Condition Occurrence
+414,0,0,,"Number of condition occurrence records, by condition_status_concept_id",condition_status_concept_id,,,,,1,Condition Occurrence
+415,0,0,,"Number of condition occurrence records, by condition_type_concept_id",condition_type_concept_id,,,,,1,Condition Occurrence
+416,0,0,,"Number of condition occurrence records, by condition_status_concept_id, condition_type_concept_id",condition_status_concept_id,condition_type_concept_id,,,,1,Condition Occurrence
 420,0,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,,1,Condition Occurrence
 425,0,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,,1,Condition Occurrence
 424,0,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases,0,Condition Occurrence

--- a/inst/sql/sql_server/analyses/414.sql
+++ b/inst/sql/sql_server/analyses/414.sql
@@ -1,0 +1,25 @@
+-- 414	Number of condition occurrence records, by condition_status_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	414 AS analysis_id,
+	CAST(co.condition_status_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(*) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_414
+FROM 
+	@cdmDatabaseSchema.condition_occurrence co
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	co.person_id = op.person_id
+AND 
+	co.condition_start_date >= op.observation_period_start_date
+AND 
+	co.condition_start_date <= op.observation_period_end_date
+GROUP BY 
+	co.condition_status_concept_id;

--- a/inst/sql/sql_server/analyses/415.sql
+++ b/inst/sql/sql_server/analyses/415.sql
@@ -1,0 +1,25 @@
+-- 415	Number of condition occurrence records, by condition_type_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	415 AS analysis_id,
+	CAST(co.condition_type_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(*) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_415
+FROM 
+	@cdmDatabaseSchema.condition_occurrence co
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	co.person_id = op.person_id
+AND 
+	co.condition_start_date >= op.observation_period_start_date
+AND 
+	co.condition_start_date <= op.observation_period_end_date
+GROUP BY 
+	co.condition_type_concept_id;

--- a/inst/sql/sql_server/analyses/416.sql
+++ b/inst/sql/sql_server/analyses/416.sql
@@ -1,0 +1,25 @@
+-- 416	Number of condition occurrence records, by condition_status_concept_id, condition_type_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	416 AS analysis_id,
+	CAST(co.condition_status_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(co.condition_type_concept_id AS VARCHAR(255))   AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(*) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_416
+FROM 
+	@cdmDatabaseSchema.condition_occurrence co
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	co.person_id = op.person_id
+AND 
+	co.condition_start_date >= op.observation_period_start_date
+AND 
+	co.condition_start_date <= op.observation_period_end_date
+GROUP BY 
+	co.condition_status_concept_id, co.condition_type_concept_id;


### PR DESCRIPTION
Added new analyses 414, 415, and 416.  These reports count records (within a valid OP) in CONDITION_OCCURRENCE stratifying by:

414: condition_status_concept_id
415: condition_type_concept_id
416: condition_status_concept_id, condition_type_concept_id

To test:

```r
Achilles::achilles(
  connectionDetails = connectionDetails,
  cdmDatabaseSchema = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema,
  outputFolder = "/TMP",
  analysisIds = c(414,415,416),
  updateGivenAnalysesOnly = T,
  createTable = F
)
```

This was successfully tested against two databases in the ops environment.