### PR TITLE
V5.4 support

### DIFF
--- a/inst/sql/sql_server/analyses/1203.sql
+++ b/inst/sql/sql_server/analyses/1203.sql
@@ -3,7 +3,10 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 SELECT 
 	1203 AS analysis_id,
-	CAST(vo.discharge_to_concept_id AS VARCHAR(255)) AS stratum_1,
+	{@cdmVersion == '5.4'} ? 
+		{CAST(vo.discharged_to_concept_id AS VARCHAR(255)) AS stratum_1,}
+		:
+		{CAST(vo.discharge_to_concept_id AS VARCHAR(255)) AS stratum_1,}
 	CAST(NULL AS VARCHAR(255)) AS stratum_2,
 	CAST(NULL AS VARCHAR(255)) AS stratum_3,
 	CAST(NULL AS VARCHAR(255)) AS stratum_4,
@@ -22,6 +25,13 @@ AND
 AND 
 	vo.visit_start_date <= op.observation_period_end_date
 WHERE 
-	vo.discharge_to_concept_id != 0
+	{@cdmVersion == '5.4'} ? 
+		{vo.discharged_to_concept_id != 0}
+		:
+		{vo.discharge_to_concept_id != 0}
 GROUP BY 
-	vo.discharge_to_concept_id;
+	{@cdmVersion == '5.4'} ? 
+		{vo.discharged_to_concept_id;}
+		:
+		{vo.discharge_to_concept_id;}
+

--- a/inst/sql/sql_server/analyses/1203.sql
+++ b/inst/sql/sql_server/analyses/1203.sql
@@ -3,7 +3,7 @@
 --HINT DISTRIBUTE_ON_KEY(stratum_1)
 SELECT 
 	1203 AS analysis_id,
-	{@cdmVersion == '5.4'} ? 
+	{@cdmVersion in ('5.4','5.4.0')} ? 
 		{CAST(vo.discharged_to_concept_id AS VARCHAR(255)) AS stratum_1,}
 		:
 		{CAST(vo.discharge_to_concept_id AS VARCHAR(255)) AS stratum_1,}
@@ -25,12 +25,12 @@ AND
 AND 
 	vo.visit_start_date <= op.observation_period_end_date
 WHERE 
-	{@cdmVersion == '5.4'} ? 
+	{@cdmVersion in ('5.4','5.4.0')} ? 
 		{vo.discharged_to_concept_id != 0}
 		:
 		{vo.discharge_to_concept_id != 0}
 GROUP BY 
-	{@cdmVersion == '5.4'} ? 
+	{@cdmVersion in ('5.4','5.4.0')} ? 
 		{vo.discharged_to_concept_id;}
 		:
 		{vo.discharge_to_concept_id;}

--- a/inst/sql/sql_server/analyses/1900.sql
+++ b/inst/sql/sql_server/analyses/1900.sql
@@ -61,16 +61,34 @@ cnt as count_value
   union
   select 'visit_detail' as table_name, 'visit_detail_source_value' as column_name, visit_detail_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where visit_detail_concept_id = 0 group by visit_detail_source_value
   union
-  select 'visit_detail' as table_name, 'admitting_source_value' as column_name, admitting_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where admitting_source_concept_id = 0 group by admitting_source_value
-  union
-  select 'visit_detail' as table_name, 'discharge_to_source_value' as column_name, admitting_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where discharge_to_concept_id = 0 group by discharge_to_source_value
+  {@cdmVersion == '5.4'} ? 
+	{
+	select 'visit_detail' as table_name, 'admitted_from_source_value' as column_name, admitted_from_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where admitted_from_concept_id = 0 group by admitted_from_source_value
+	union
+	select 'visit_detail' as table_name, 'discharged_to_source_value' as column_name, discharged_to_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where discharged_to_concept_id = 0 group by discharged_to_source_value
+	}
+	:
+	{
+	select 'visit_detail' as table_name, 'admitting_source_value' as column_name, admitting_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where admitting_source_concept_id = 0 group by admitting_source_value
+	union
+	select 'visit_detail' as table_name, 'discharge_to_source_value' as column_name, discharge_to_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where discharge_to_concept_id = 0 group by discharge_to_source_value
+	}
   }
   union
   select 'visit_occurrence' as table_name, 'visit_source_value' as column_name, visit_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where visit_concept_id = 0 group by visit_source_value
   union
-  select 'visit_occurrence' as table_name, 'admitting_source_value' as column_name, admitting_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where admitting_source_concept_id = 0 group by admitting_source_value
-  union
-  select 'visit_occurrence' as table_name, 'discharge_to_source_value' as column_name, discharge_to_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where discharge_to_concept_id = 0 group by discharge_to_source_value
+  {@cdmVersion == '5.4'} ?
+	{
+	select 'visit_occurrence' as table_name, 'admitted_from_source_value' as column_name, admitted_from_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where  admitted_from_concept_id = 0 group by admitted_from_source_value
+    union
+    select 'visit_occurrence' as table_name, 'discharged_to_source_value' as column_name, discharged_to_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where discharged_to_concept_id = 0 group by discharged_to_source_value
+	}
+	:
+	{
+	select 'visit_occurrence' as table_name, 'admitting_source_value' as column_name, admitting_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where admitting_source_concept_id = 0 group by admitting_source_value
+    union
+    select 'visit_occurrence' as table_name, 'discharge_to_source_value' as column_name, discharge_to_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where discharge_to_concept_id = 0 group by discharge_to_source_value
+	}		
   union
   select 'device_exposure' as table_name, 'device_source_value' as column_name, device_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.device_exposure where device_concept_id = 0 group by device_source_value
   union

--- a/inst/sql/sql_server/analyses/1900.sql
+++ b/inst/sql/sql_server/analyses/1900.sql
@@ -61,7 +61,7 @@ cnt as count_value
   union
   select 'visit_detail' as table_name, 'visit_detail_source_value' as column_name, visit_detail_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where visit_detail_concept_id = 0 group by visit_detail_source_value
   union
-  {@cdmVersion == '5.4'} ? 
+  {@cdmVersion in ('5.4','5.4.0')} ? 
 	{
 	select 'visit_detail' as table_name, 'admitted_from_source_value' as column_name, admitted_from_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_detail where admitted_from_concept_id = 0 group by admitted_from_source_value
 	union
@@ -77,7 +77,7 @@ cnt as count_value
   union
   select 'visit_occurrence' as table_name, 'visit_source_value' as column_name, visit_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where visit_concept_id = 0 group by visit_source_value
   union
-  {@cdmVersion == '5.4'} ?
+  {@cdmVersion in ('5.4','5.4.0')} ?
 	{
 	select 'visit_occurrence' as table_name, 'admitted_from_source_value' as column_name, admitted_from_source_value as source_value, count_big(*) as cnt from @cdmDatabaseSchema.visit_occurrence where  admitted_from_concept_id = 0 group by admitted_from_source_value
     union


### PR DESCRIPTION
Here are the updates to Achilles to support cdm v5.4.  After discussing with @clairblacketer , we decided to leave cdmVersion as is for now.  I will create a forum post explaining upcoming future changes to cdmVersion and why cdm_source is important.

This was successfully tested multiple ways against three databases.  This was tested by running Achilles against databases with both v5.3.1 and v5.4 CDMs.  The cdm version, if not given, is determined by CDM_SOURCE and need not be supplied.  To test, you can run something similar to the following:

```r
connectionDetails <- DatabaseConnector::createConnectionDetails( rdbms, server, etc... )

cdmDatabaseSchema     <- "cdm_v540"
resultsDatabaseSchema <- "results_v540"

Achilles::achilles(
  connectionDetails = connectionDetails,
  cdmDatabaseSchema = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema,
  outputFolder = "your output path"
)

cdmDatabaseSchema     <- "cdm_v531"
resultsDatabaseSchema <- "results_v531"

Achilles::achilles(
  connectionDetails = connectionDetails,
  cdmDatabaseSchema = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema,
  outputFolder = "your output path"
)
```