### PR TITLE
Fixes issue #622

### DIFF
--- a/R/performTemporalCharacterization.r
+++ b/R/performTemporalCharacterization.r
@@ -57,7 +57,7 @@
 #'                                If not specified, data for all analysis will be returned. Ignored if \code{conceptId} is given. 
 #' @param conceptId               (OPTIONAL) A SNOMED concept_id from the \code{CONCEPT} table for which a monthly Achilles analysis exists.
 #'                                If not specified, all concepts for a given analysis will be returned.
-#' @param outputFile              CSV file where temporal characterization will be written
+#' @param outputFile              CSV file where temporal characterization will be written. Default is temporal-characterization.csv.
 #'
 #' @return
 #' A csv file with temporal analyses for each time series
@@ -100,7 +100,7 @@ performTemporalCharacterization <- function(
 									resultsDatabaseSchema, 
 									analysisIds = NULL, 
 									conceptId   = NULL,
-									outputFile)
+									outputFile  = "temporal-characterization.csv")
 {
 
 	# Minimum number of months of data to perform temporal characterization

--- a/man/performTemporalCharacterization.Rd
+++ b/man/performTemporalCharacterization.Rd
@@ -10,7 +10,7 @@ performTemporalCharacterization(
   resultsDatabaseSchema,
   analysisIds = NULL,
   conceptId = NULL,
-  outputFile
+  outputFile = "temporal-characterization.csv"
 )
 }
 \arguments{
@@ -34,7 +34,7 @@ If not specified, data for all analysis will be returned. Ignored if \code{conce
 \item{conceptId}{(OPTIONAL) A SNOMED concept_id from the \code{CONCEPT} table for which a monthly Achilles analysis exists.
 If not specified, all concepts for a given analysis will be returned.}
 
-\item{outputFile}{CSV file where temporal characterization will be written}
+\item{outputFile}{CSV file where temporal characterization will be written. Default is temporal-characterization.csv.}
 }
 \value{
 A csv file with temporal analyses for each time series


### PR DESCRIPTION
Successfully tested on redshift.  The parameter, outputFile, now defaults to "temporal-characterization.csv" and is created in pwd if not otherwise specified.  To test:

```
Achilles::performTemporalCharacterization(
  connectionDetails     = connectionDetails,
  cdmDatabaseSchema     = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema)
```