### PR TITLE
Fixes #651

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -132,7 +132,7 @@ achilles <- function(connectionDetails,
   sourceName = "", analysisIds, createTable = TRUE, smallCellCount = 5, cdmVersion = "5", 
   createIndices = TRUE, numThreads = 1, tempAchillesPrefix = "tmpach", dropScratchTables = TRUE, sqlOnly = FALSE,
   outputFolder = "output", verboseMode = TRUE, optimizeAtlasCache = FALSE, defaultAnalysesOnly = TRUE,
-  updateGivenAnalysesOnly = FALSE, excludeAnalysisIds = c(), sqlDialect = NULL) {
+  updateGivenAnalysesOnly = FALSE, excludeAnalysisIds, sqlDialect = NULL) {
   totalStart <- Sys.time()
   achillesSql <- c()
 
@@ -213,13 +213,9 @@ achilles <- function(connectionDetails,
     analysisDetails <- analysisDetails[analysisDetails$IS_DEFAULT == 1, ]
   }
 
-  # Remove unwanted analyses, if any are specified
-  if (length(excludeAnalysisIds) != 0) {
+  # Remove unwanted analyses that have not already been excluded, if any are specified
+  if (!missing(excludeAnalysisIds) && any(analysisDetails$ANALYSIS_ID %in% excludeAnalysisIds)) {
     analysisDetails <- analysisDetails[-which(analysisDetails$ANALYSIS_ID %in% excludeAnalysisIds),]
-  }
-
-  if (cdmVersion < "5.3") {
-    analysisDetails <- analysisDetails[!analysisDetails$ANALYSIS_ID == 1425, ]
   }
 
   resultsTables <- list(list(detailType = "results",


### PR DESCRIPTION
Successfully tested on redshift against cdm v5.3, using the following two test cases:

```r
# Test 1: without using excludeAnalysisIds to ensure the fix didn't break anything
Achilles::achilles(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema,
                   cdmVersion = "5.3",
                   outputFolder = "D:/sandbox/Achilles")

# Test 2: Using excludeAnalysisIds to exclude non-default analyses
analysisDetails <- Achilles::getAnalysisDetails()
excludeAnalysisIds <- analysisDetails[analysisDetails$IS_DEFAULT==0,]$ANALYSIS_ID
Achilles::achilles(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema,
                   cdmVersion = "5.3",
                   excludeAnalysisIds = excludeAnalysisIds,
                   outputFolder = "D:/sandbox/Achilles")

```  