### PR TITLE
Fixes #660 and #650

### DIFF
--- a/R/listMissingAnalyses.r
+++ b/R/listMissingAnalyses.r
@@ -61,8 +61,8 @@ listMissingAnalyses <- function(connectionDetails, resultsDatabaseSchema) {
   print("Retrieving previously computed achilles_results and achilles_results_dist data...")
 
   sql <- "select distinct analysis_id from @results_schema.achilles_results
-        union
-select distinct analysis_id from @results_schema.achilles_results_dist;"
+          union
+         select distinct analysis_id from @results_schema.achilles_results_dist;"
 
   sql <- SqlRender::render(sql, results_schema = resultsDatabaseSchema)
   sql <- SqlRender::translate(sql, targetDialect = connectionDetails$dbms)
@@ -75,7 +75,6 @@ select distinct analysis_id from @results_schema.achilles_results_dist;"
 
   colsToDisplay <- c("ANALYSIS_ID",
                      "DISTRIBUTION",
-                     "COST",
                      "CATEGORY",
                      "IS_DEFAULT",
                      "ANALYSIS_NAME")

--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -1,292 +1,292 @@
-ANALYSIS_ID,DISTRIBUTION,COST,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,IS_DEFAULT,CATEGORY
-0,-1,0,,Source name,,,,,,1,General
-1,0,0,,Number of persons,,,,,,1,Person
-2,0,0,,Number of persons by gender,gender_concept_id,,,,,1,Person
-3,0,0,,Number of persons by year of birth,year_of_birth,,,,,1,Person
-4,0,0,,Number of persons by race,race_concept_id,,,,,1,Person
-5,0,0,,Number of persons by ethnicity,ethnicity_concept_id,,,,,1,Person
-7,0,0,,Number of persons with invalid provider_id,,,,,,1,Person
-8,0,0,,Number of persons with invalid location_id,,,,,,1,Person
-9,0,0,,Number of persons with invalid care_site_id,,,,,,1,Person
-10,0,0,,Number of all persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1,Person
-11,0,0,,Number of non-deceased persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1,Person
-12,0,0,,Number of persons by race and ethnicity,race_concept_id,ethnicity_concept_id,,,,1,Person
-101,0,0,,"Number of persons by age, with age at first observation period",age,,,,,1,Person
-102,0,0,,"Number of persons by gender by age, with age at first observation period",gender_concept_id,age,,,,1,Person
-103,1,0,,Distribution of age at first observation period,,,,,,1,Observation Period
-104,1,0,,Distribution of age at first observation period by gender,gender_concept_id,,,,,1,Observation Period
-105,1,0,,Length of observation (days) of first observation period,,,,,,1,Observation Period
-106,1,0,,Length of observation (days) of first observation period by gender,gender_concept_id,,,,,1,Observation Period
-107,1,0,,Length of observation (days) of first observation period by age decile,age decile,,,,,1,Observation Period
-108,0,0,,"Number of persons by length of observation period, in 30d increments",Observation period length 30d increments,,,,,1,Observation Period
-109,0,0,,Number of persons with continuous observation in each year,calendar year,,,,,1,Observation Period
-110,0,0,,Number of persons with continuous observation in each month,calendar month,,,,,1,Observation Period
-111,0,0,,Number of persons by observation period start month,calendar month,,,,,1,Observation Period
-112,0,0,,Number of persons by observation period end month,calendar month,,,,,1,Observation Period
-113,0,0,,Number of persons by number of observation periods,number of observation periods,,,,,1,Observation Period
-114,0,0,,Number of persons with observation period before year-of-birth,,,,,,1,Observation Period
-115,0,0,,Number of persons with observation period end < observation period start,,,,,,1,Observation Period
-116,0,0,,Number of persons with at least one day of observation in each year by gender and age decile,calendar year,gender_concept_id,age decile,,,1,Observation Period
-117,0,0,,Number of persons with at least one day of observation in each month,calendar month,,,,,1,Observation Period
-118,0,0,,Number of observation periods with invalid person_id,,,,,,1,Observation Period
-119,0,0,,Number of observation period records by period_type_concept_id,period_type_concept_id,,,,,1,Observation Period
-200,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id",visit_concept_id,,,,,1,Visit Occurrence
-201,0,0,,"Number of visit occurrence records, by visit_concept_id",visit_concept_id,,,,,1,Visit Occurrence
-202,0,0,,"Number of persons by visit occurrence start month, by visit_concept_id",visit_concept_id,calendar month,,,,1,Visit Occurrence
-203,1,0,,Number of distinct visit occurrence concepts per person,,,,,,1,Visit Occurrence
-204,0,0,,"Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile",visit_concept_id,calendar year,gender_concept_id,age decile,,1,Visit Occurrence
-206,1,0,,Distribution of age by visit_concept_id,visit_concept_id,gender_concept_id,,,,1,Visit Occurrence
-207,0,0,,Number of visit records with invalid person_id,,,,,,1,Visit Occurrence
-209,0,0,,Number of visit records with invalid care_site_id,,,,,,1,Visit Occurrence
-210,0,0,,Number of visit_occurrence records outside a valid observation period,,,,,,1,Observation Period
-211,0,0,,Number of visit records with end date < start date,,,,,,1,Visit Occurrence
-212,0,0,,"Number of persons with at least one visit occurrence, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Visit Occurrence
-213,1,0,,Distribution of length of stay by visit_concept_id,visit_concept_id,,,,,1,Visit Occurrence
-220,0,0,,Number of visit occurrence records by visit occurrence start month,calendar month,,,,,1,Visit Occurrence
-221,0,0,,Number of persons by visit start year,calendar year,,,,,1,Visit Occurrence
-225,0,0,,Number of visit_occurrence records by visit_source_concept_id,visit_source_concept_id,,,,,1,Visit Occurrence
-226,0,0,,Number of records by domain by visit_concept_id,visit_source_concept_id,cdm_table_name,,,,1,Visit Occurrence
-230,0,0,,Number of visit_occurrence records inside valid observation period,,,,,,1,Observation Period
-231,0,0,,Proportion of people with at least one visit_occurrence record outside a valid observation period,Proportion,Number of people with a visit_occurrence record outside a valid observation period,Number of people in visit_occurrence,,,1,Observation Period
-232,0,0,,Proportion of visit_occurrence records outside a valid observation period,Proportion,Number of visit_occurrence records outside a valid observation period,Number of visit_occurrence records,,,1,Observation Period
-300,0,0,,Number of providers,,,,,,1,Provider
-301,0,0,,Number of providers by specialty concept_id,specialty_concept_id,,,,,1,Provider
-303,0,0,,Number of providers records by specialty_concept_id and visit_concept_id,specialty_concept_id,visit_concept_id,,,,1,Provider
-325,0,0,,Number of provider records by specialty_source_concept_id,specialty_source_concept_id,,,,,1,Provider
-400,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id",condition_concept_id,,,,,1,Condition Occurrence
-401,0,0,,"Number of condition occurrence records, by condition_concept_id",condition_concept_id,,,,,1,Condition Occurrence
-402,0,0,,"Number of persons by condition occurrence start month, by condition_concept_id",condition_concept_id,calendar month,,,,1,Condition Occurrence
-403,1,0,,Number of distinct condition occurrence concepts per person,,,,,,1,Condition Occurrence
-404,0,0,,"Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1,Condition Occurrence
-405,0,0,,"Number of condition occurrence records, by condition_concept_id by condition_type_concept_id",condition_concept_id,condition_type_concept_id,,,,1,Condition Occurrence
-406,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1,Condition Occurrence
-409,0,0,,Number of condition occurrence records with invalid person_id,,,,,,1,Condition Occurrence
-410,0,0,,Number of condition occurrence records outside valid observation period,,,,,,1,Observation Period
-411,0,0,,Number of condition occurrence records with end date < start date,,,,,,1,Condition Occurrence
-412,0,0,,Number of condition occurrence records with invalid provider_id,,,,,,1,Condition Occurrence
-413,0,0,,Number of condition occurrence records with invalid visit_id,,,,,,1,Condition Occurrence
-414,0,0,,"Number of condition occurrence records, by condition_status_concept_id",condition_status_concept_id,,,,,1,Condition Occurrence
-415,0,0,,"Number of condition occurrence records, by condition_type_concept_id",condition_type_concept_id,,,,,1,Condition Occurrence
-416,0,0,,"Number of condition occurrence records, by condition_status_concept_id, condition_type_concept_id",condition_status_concept_id,condition_type_concept_id,,,,1,Condition Occurrence
-420,0,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,,1,Condition Occurrence
-425,0,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,,1,Condition Occurrence
-424,0,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases,0,Condition Occurrence
-430,0,0,,Number of condition_occurrence records inside a valid observation period,,,,,,1,Observation Period
-431,0,0,,Proportion of people with at least one condition_occurrence record outside a valid observation period,Proportion,Number of people with a condition_occurrence record outside a valid observation period,Number of people in condition_occurrence,,,1,Observation Period
-432,0,0,,Proportion of condition_occurrence records outside a valid observation period,Proportion,Number of condition_occurrence records outside a valid observation period,Number of condition_occurrence records,,,1,Observation Period
-500,0,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,,1,Death
-501,0,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,,1,Death
-502,0,0,,Number of persons by death month,calendar month,,,,,1,Death
-504,0,0,,"Number of persons with a death, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Death
-505,0,0,,"Number of death records, by death_type_concept_id",death_type_concept_id,,,,,1,Death
-506,1,0,,Distribution of age at death by gender,gender_concept_id,,,,,1,Death
-509,0,0,,Number of death records with invalid person_id,,,,,,1,Death
-510,0,0,,Number of death records outside valid observation period,,,,,,1,Observation Period
-511,1,0,,Distribution of time from death to last condition,,,,,,1,Death
-512,1,0,,Distribution of time from death to last drug,,,,,,1,Death
-513,1,0,,Distribution of time from death to last visit,,,,,,1,Death
-514,1,0,,Distribution of time from death to last procedure,,,,,,1,Death
-515,1,0,,Distribution of time from death to last observation,,,,,,1,Death
-525,0,0,,Number of death records by cause_source_concept_id,cause_source_concept_id,,,,,1,Death
-530,0,0,,Number of death records inside a valid observation period,,,,,,1,Observation Period
-531,0,0,,Proportion of people with at least one death record outside a valid observation period,Proportion,Number of people with a death record outside a valid observation period,Number of people in death,,,1,Observation Period
-532,0,0,,Proportion of death records that occur outside a valid observation period,Proportion,Number of records in death outside a valid observation period,Number of death records,,,1,Observation Period
-600,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
-601,0,0,,"Number of procedure occurrence records, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
-602,0,0,,"Number of persons by procedure occurrence start month, by procedure_concept_id",procedure_concept_id,calendar month,,,,1,Procedure Occurrence
-603,1,0,,Number of distinct procedure occurrence concepts per person,,,,,,1,Procedure Occurrence
-604,0,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile",procedure_concept_id,calendar year,gender_concept_id,age decile,,1,Procedure Occurrence
-605,0,0,,"Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id",procedure_concept_id,procedure_type_concept_id,,,,1,Procedure Occurrence
-606,1,0,,Distribution of age by procedure_concept_id,procedure_concept_id,gender_concept_id,,,,1,Procedure Occurrence
-609,0,0,,Number of procedure occurrence records with invalid person_id,,,,,,1,Procedure Occurrence
-610,0,0,,Number of procedure occurrence records outside valid observation period,,,,,,1,Observation Period
-612,0,0,,Number of procedure occurrence records with invalid provider_id,,,,,,1,Procedure Occurrence
-613,0,0,,Number of procedure occurrence records with invalid visit_id,,,,,,1,Procedure Occurrence
-620,0,0,,Number of procedure occurrence records  by procedure occurrence start month,calendar month,,,,,1,Procedure Occurrence
-625,0,0,,Number of procedure_occurrence records by procedure_source_concept_id,procedure_source_concept_id,,,,,1,Procedure Occurrence
-624,0,0,,Number of distinct people with co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,num_people,num_cases,0,Procedure Occurrence
-630,0,0,,Number of procedure_occurrence records inside a valid observation period,,,,,,1,Observation Period
-631,0,0,,Proportion of people with at least one procedure_occurrence record outside a valid observation period,Proportion,Number of people with a procedure_occurrence record outside a valid observation period,Number of people in procedure_occurrence,,,1,Observation Period
-632,0,0,,Proportion of procedure_occurrence records outside a valid observation period,Proportion,Number of records in procedure_occurrence outside a valid observation period,Number of procedure_occurrence records,,,1,Observation Period
-691,0,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,,1,Procedure Occurrence
-700,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
-701,0,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
-702,0,0,,"Number of persons by drug exposure start month, by drug_concept_id",drug_concept_id,calendar month,,,,1,Drug Exposure
-703,1,0,,Number of distinct drug exposure concepts per person,,,,,,1,Drug Exposure
-704,0,0,,"Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1,Drug Exposure
-705,0,0,,"Number of drug exposure records, by drug_concept_id by drug_type_concept_id",drug_concept_id,drug_type_concept_id,,,,1,Drug Exposure
-706,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1,Drug Exposure
-709,0,0,,Number of drug exposure records with invalid person_id,,,,,,1,Drug Exposure
-710,0,0,,Number of drug exposure records outside valid observation period,,,,,,1,Observation Period
-711,0,0,,Number of drug exposure records with end date < start date,,,,,,1,Drug Exposure
-712,0,0,,Number of drug exposure records with invalid provider_id,,,,,,1,Drug Exposure
-713,0,0,,Number of drug exposure records with invalid visit_id,,,,,,1,Drug Exposure
-715,1,0,,Distribution of days_supply by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
-716,1,0,,Distribution of refills by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
-717,1,0,,Distribution of quantity by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
-720,0,0,,Number of drug exposure records  by drug exposure start month,calendar month,,,,,1,Drug Exposure
-725,0,0,,Number of drug_exposure records by drug_source_concept_id,drug_source_concept_id,,,,,1,Drug Exposure
-724,0,0,,Number of distinct people with co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,num_people,num_cases,0,Drug Exposure
-730,0,0,,Number of drug_exposure records inside a valid observation period,,,,,,1,Observation Period
-731,0,0,,Proportion of people with at least one drug_exposure record outside a valid observation period,Proportion,Number of people with a drug_exposure record outside a valid observation period,Number of people in drug_exposure,,,1,Observation Period
-732,0,0,,Proportion of drug_exposure records outside a valid observation period,Proportion,Number of records in drug_exposure outside a valid observation period,Number of drug_exposure records,,,1,Observation Period
-791,0,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,,1,Drug Exposure
-800,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,,1,Observation
-801,0,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,,1,Observation
-802,0,0,,"Number of persons by observation occurrence start month, by observation_concept_id",observation_concept_id,calendar month,,,,1,Observation
-803,1,0,,Number of distinct observation occurrence concepts per person,,,,,,1,Observation
-804,0,0,,"Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile",observation_concept_id,calendar year,gender_concept_id,age decile,,1,Observation
-805,0,0,,"Number of observation occurrence records, by observation_concept_id by observation_type_concept_id",observation_concept_id,observation_type_concept_id,,,,1,Observation
-806,1,0,,Distribution of age by observation_concept_id,observation_concept_id,gender_concept_id,,,,1,Observation
-807,0,0,,"Number of observation occurrence records, by observation_concept_id and unit_concept_id",observation_concept_id,unit_concept_id,,,,1,Observation
-809,0,0,,Number of observation records with invalid person_id,,,,,,1,Observation
-810,0,0,,Number of observation records outside valid observation period,,,,,,1,Observation Period
-812,0,0,,Number of observation records with invalid provider_id,,,,,,1,Observation
-813,0,0,,Number of observation records with invalid visit_id,,,,,,1,Observation
-814,0,0,,"Number of observation records with no value (numeric, string, or concept)",,,,,,1,Observation
-815,1,0,,"Distribution of numeric values, by observation_concept_id and unit_concept_id",,,,,,1,Observation
-820,0,0,,Number of observation records  by observation start month,calendar month,,,,,1,Observation
-822,0,0,,"Number of observation records, by observation_concept_id and value_as_concept_id",observation_concept_id,value_as_concept_id,,,,1,Observation
-823,0,0,,"Number of observation records, by observation_concept_id and qualifier_concept_id",observation_concept_id,qualifier_concept_id,,,,1,Observation
-824,0,0,,Number of distinct people with co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,num_people,num_cases,0,Observation
-825,0,0,,Number of observation records by observation_source_concept_id,observation_source_concept_id,,,,,1,Observation
-826,0,0,,Number of observation records by value_as_concept_id,value_as_concept_id,,,,,1,Observation
-827,0,0,,Number of observation records by unit_concept_id,unit_as_concept_id,,,,,1,Observation
-830,0,0,,Number of observation records inside a valid observation period,,,,,,1,Observation Period
-831,0,0,,Proportion of people with at least one observation record outside a valid observation period,Proportion,Number of people with a observation record outside a valid observation period,Number of people in observation,,,1,Observation Period
-832,0,0,,Proportion of observation records outside a valid observation period,Proportion,Number of records in observation outside a valid observation period,Number of observation records,,,1,Observation Period
-891,0,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,,1,Observation
-900,0,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
-901,0,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
-902,0,0,,"Number of persons by drug era start month, by drug_concept_id",drug_concept_id,calendar month,,,,1,Drug Era
-903,1,0,,Number of distinct drug era concepts per person,,,,,,1,Drug Era
-904,0,0,,"Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1,Drug Era
-906,1,0,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1,Drug Era
-907,1,0,,"Distribution of drug era length, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
-908,0,0,,Number of drug eras without valid person,,,,,,1,Drug Era
-910,0,0,,Number of drug_era records outside valid observation period,,,,,,1,Observation Period
-911,0,0,,Number of drug eras with end date < start date,,,,,,1,Drug Era
-920,0,0,,Number of drug era records by drug era start month,calendar month,,,,,1,Drug Era
-930,0,0,,Number of drug_era records inside a valid observation period,,,,,,1,Observation Period
-931,0,0,,Proportion of people with at least one drug_era record outside a valid observation period,Proportion,Number of people with a drug_era record outside a valid observation period,Number of people in drug_era,,,1,Observation Period
-932,0,0,,Proportion of drug_era records outside a valid observation period,Proportion,Number of records in drug_era outside a valid observation period,Number of drug_era records,,,1,Observation Period
-1000,0,0,,"Number of persons with at least one condition era, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
-1001,0,0,,"Number of condition era records, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
-1002,0,0,,"Number of persons by condition era start month, by condition_concept_id",condition_concept_id,calendar month,,,,1,Condition Era
-1003,1,0,,Number of distinct condition era concepts per person,,,,,,1,Condition Era
-1004,0,0,,"Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1,Condition Era
-1006,1,0,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1,Condition Era
-1007,1,0,,"Distribution of condition era length, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
-1008,0,0,,Number of condition eras without valid person,,,,,,1,Condition Era
-1010,0,0,,Number of condition_era records outside a valid observation period,,,,,,1,Observation Period
-1011,0,0,,Number of condition eras with end date < start date,,,,,,1,Condition Era
-1020,0,0,,Number of condition era records by condition era start month,calendar month,,,,,1,Condition Era
-1030,0,0,,Number of condition_era records inside a valid observation period,,,,,,1,Observation Period
-1031,0,0,,Proportion of people with at least one condition_era record outside a valid observation period,Proportion,Number of people with a condition_era record outside a valid observation period,Number of people in condition_era,,,1,Observation Period
-1032,0,0,,Proportion of condition_era records outside a valid observation period,Proportion,Number of records in condition_era outside a valid observation period,Number of condition_era records,,,1,Observation Period
-1100,0,0,,Number of persons by location 3-digit zip,3-digit zip,,,,,1,Location
-1101,0,0,,Number of persons by location state,state,,,,,1,Location
-1102,0,0,,Number of care sites by location 3-digit zip,3-digit zip,,,,,1,Location
-1103,0,0,,Number of care sites by location state,state,,,,,1,Location
-1200,0,0,,Number of persons by place of service,place_of_service_concept_id,,,,,1,Care Site
-1201,0,0,,Number of visits by place of service,place_of_service_concept_id,,,,,1,Care Site
-1202,0,0,,Number of care sites by place of service,place_of_service_concept_id,,,,,1,Care Site
-1203,0,0,,Number of visits by place of service discharge type,discharge_to_concept_id,,,,,1,Care Site
-1300,0,0,,"Number of persons with at least one visit detail, by visit_detail_concept_id",visit_detail_concept_id,,,,,1,Visit Detail
-1301,0,0,,"Number of visit detail records, by visit_detail_concept_id",visit_detail_concept_id,,,,,1,Visit Detail
-1302,0,0,,"Number of persons by visit detail start month, by visit_detail_concept_id",visit_detail_concept_id,calendar month,,,,1,Visit Detail
-1303,1,0,,Number of distinct visit detail concepts per person,,,,,,1,Visit Detail
-1304,0,0,,"Number of persons with at least one visit detail, by visit_detail_concept_id by calendar year by gender by age decile",visit_detail_concept_id,calendar year,gender_concept_id,age decile,,1,Visit Detail
-1306,1,0,,Distribution of age by visit_detail_concept_id,visit_detail_concept_id,gender_concept_id,,,,1,Visit Detail
-1307,0,0,,Number of visit records with invalid person_id,,,,,,1,Visit Detail
-1309,0,0,,Number of visit_detail records with invalid care_site_id,,,,,,1,Visit Detail
-1310,0,0,,Number of visit_detail records outside a valid observation period,,,,,,1,Observation Period
-1311,0,0,,Number of visit_detail records with end date < start date,,,,,,1,Visit Detail
-1312,0,0,,"Number of persons with at least one visit detail, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Visit Detail
-1313,1,0,,Distribution of length of stay by visit_detail_concept_id,visit_detail_concept_id,,,,,1,Visit Detail
-1320,0,0,,Number of visit detail records by visit detail start month,calendar month,,,,,1,Visit Detail
-1321,0,0,,Number of persons by visit start year,calendar year,,,,,1,Visit Detail
-1325,0,0,,Number of visit_detail records by visit_detail_source_concept_id,visit_detail_source_concept_id,,,,,1,Visit Detail
-1326,0,0,,Number of records by domain by visit_detail_concept_id,visit_detail_source_concept_id,cdm_table_name,,,,1,Visit Detail
-1330,0,0,,Number of visit_detail records inside a valid observation period,,,,,,1,Observation Period
-1331,0,0,,Proportion of people with at least one visit_detail record outside a valid observation period,Proportion,Number of people with a visit_detail record outside a valid observation period,Number of people in visit_detail,,,1,Observation Period
-1332,0,0,,Proportion of visit_detail records outside a valid observation period,Proportion,Number of records in visit_detail outside a valid observation period,Number of visit_detail records,,,1,Observation Period
-1406,1,0,,Length of payer plan (days) of first payer plan period by gender,gender_concept_id,,,,,1,Payer Plan Period
-1407,1,0,,Length of payer plan (days) of first payer plan period by age decile,age_decile,,,,,1,Payer Plan Period
-1408,0,0,,"Number of persons by length of payer plan period, in 30d increments",payer plan period length 30d increments,,,,,1,Payer Plan Period
-1409,0,0,,Number of persons with continuous payer plan in each year,calendar year,,,,,1,Payer Plan Period
-1410,0,0,,Number of persons with continuous payer plan in each month,calendar month,,,,,1,Payer Plan Period
-1411,0,0,,Number of persons by payer plan period start month,calendar month,,,,,1,Payer Plan Period
-1412,0,0,,Number of persons by payer plan period end month,calendar month,,,,,1,Payer Plan Period
-1413,0,0,,Number of persons by number of payer plan periods,number of payer plan periods,,,,,1,Payer Plan Period
-1414,0,0,,Number of persons with payer plan period before year-of-birth,,,,,,1,Payer Plan Period
-1415,0,0,,Number of persons with payer plan period end < payer plan period start,,,,,,1,Payer Plan Period
-1425,0,0,,Number of payer_plan_period records by payer_source_concept_id,payer_source_concept_id,,,,,1,Payer Plan Period
-1502,1,1,paid_patient_copay,"Distribution of paid_patient_copay, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1503,1,1,paid_patient_coinsurance,"Distribution of paid_patient_coinsurance, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1504,1,1,paid_patient_deductible,"Distribution of paid_patient_deductible, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1505,1,1,paid_by_payer,"Distribution of paid_by_payer, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1506,1,1,paid_by_primary,"Distribution of paid_by_primary, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1507,1,1,paid_by_patient,"Distribution of paid_by_patient, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1508,1,1,total_paid,"Distribution of total_paid, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1509,1,1,paid_ingredient_cost,"Distribution of paid_ingredient_cost, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1510,1,1,paid_dispensing_fee,"Distribution of paid_dispensing_fee, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1511,1,1,total_cost,"Distribution of total_cost, by drug_concept_id",drug_concept_id,,,,,0,Cost
-1602,1,1,paid_patient_copay,"Distribution of paid_patient_copay, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1603,1,1,paid_patient_coinsurance,"Distribution of paid_patient_coinsurance, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1604,1,1,paid_patient_deductible,"Distribution of paid_patient_deductible, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1605,1,1,paid_by_payer,"Distribution of paid_by_payer, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1606,1,1,paid_by_primary,"Distribution of paid_by_primary, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1607,1,1,paid_by_patient,"Distribution of paid_by_patient, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1608,1,1,total_paid,"Distribution of total paid, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
-1610,0,1,,Number of records by revenue_code_concept_id,revenue_code_concept_id,,,,,0,Cost
-1800,0,0,,"Number of persons with at least one measurement occurrence, by measurement_concept_id",measurement_concept_id,,,,,1,Measurement
-1801,0,0,,"Number of measurement occurrence records, by measurement_concept_id",measurement_concept_id,,,,,1,Measurement
-1802,0,0,,"Number of persons by measurement occurrence start month, by measurement_concept_id",measurement_concept_id,calendar month,,,,1,Measurement
-1803,1,0,,Number of distinct mesurement occurrence concepts per person,,,,,,1,Measurement
-1804,0,0,,"Number of persons with at least one mesurement  occurrence, by measurement_concept_id by calendar year by gender by age decile",measurement_concept_id,calendar year,gender_concept_id,age decile,,1,Measurement
-1805,0,0,,"Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id",measurement_concept_id,measurement_type_concept_id,,,,1,Measurement
-1806,1,0,,Distribution of age by measurement_concept_id,measurement_concept_id,gender_concept_id,,,,1,Measurement
-1807,0,0,,"Number of measurement occurrence records, by measurement_concept_id and unit_concept_id",measurement_concept_id,unit_concept_id,,,,1,Measurement
-1809,0,0,,Number of measurement records with invalid person_id,,,,,,1,Measurement
-1810,0,0,,Number of measurement records outside valid observation period,,,,,,1,Observation Period
-1812,0,0,,Number of measurement records with invalid provider_id,,,,,,1,Measurement
-1813,0,0,,Number of measurement records with invalid visit_id,,,,,,1,Measurement
-1814,0,0,,"Number of measurement records with no value (numeric, string, or concept)",,,,,,1,Measurement
-1815,1,0,,"Distribution of numeric values, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
-1816,1,0,,"Distribution of low range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
-1817,1,0,,"Distribution of high range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
-1818,0,0,,"Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
-1820,0,0,,Number of measurement records  by measurement start month,calendar month,,,,,1,Measurement
-1821,0,0,,Number of measurement records with no numeric value,,,,,,1,Measurement
-1822,0,0,,"Number of measurement records, by measurement_concept_id and value_as_concept_id",measurement_concept_id,value_as_concept_id,,,,1,Measurement
-1823,0,0,,"Number of measurement records, by measurement_concept_id and operator_concept_id",measurement_concept_id,operator_concept_id,,,,1,Measurement
-1824,0,0,,Number of distinct people with co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,num_people,num_cases,0,Measurement
-1825,0,0,,Number of measurement records by measurement_source_concept_id,measurement_source_concept_id,,,,,1,Measurement
-1826,0,0,,Number of measurement records by value_as_concept_id,value_as_concept_id,,,,,1,Measurement
-1827,0,0,,Number of measurement records by unit_concept_id,unit_as_concept_id,,,,,1,Measurement
-1830,0,0,,Number of visit_detail records inside a valid observation period,,,,,,1,Observation Period
-1831,0,0,,Proportion of people with at least one measurement record outside a valid observation period,Proportion,Number of people with a measurement record outside a valid observation period,Number of people in measurement,,,1,Observation Period
-1832,0,0,,Proportion of measurement records outside a valid observation period,Proportion,Number of records in measurement outside a valid observation period,Number of measurement records,,,1,Observation Period
-1833,0,0,,Proportion of measurement records inside a valid observation period and without a value,measurement_concept_id,Number of measurement records with no value for the given measurement_concept_id,proportion,,,1,Measurement
-1891,0,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,,1,Measurement
-1900,0,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,,1,Completeness
-2000,0,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,,1,Completeness
-2001,0,0,,Number of patients with at least 1 Dx and 1 Proc,,,,,,1,Completeness
-2002,0,0,,"Number of patients with at least 1 Meas, 1 Dx and 1 Rx",,,,,,1,Completeness
-2003,0,0,,Number of patients with at least 1 Visit,,,,,,1,Completeness
-2004,0,0,,Number of distinct patients that overlap between specific domains,domain_bit_string,proportion_of_overlap,,,,1,Completeness
-2100,0,0,,"Number of persons with at least one device exposure, by device_concept_id",device_concept_id,,,,,1,Completeness
-2101,0,0,,"Number of device exposure records, by device_concept_id",device_concept_id,,,,,1,Device Exposure
-2102,0,0,,"Number of persons by device records  start month, by device_concept_id",device_concept_id,calendar month,,,,1,Device Exposure
-2104,0,0,,"Number of persons with at least one device exposure, by device_concept_id by calendar year by gender by age decile",device_concept_id,calendar year,gender_concept_id,age decile,,1,Device Exposure
-2105,0,0,,"Number of device exposure records, by device_concept_id by device_type_concept_id",device_concept_id,device_type_concept_id,,,,1,Device Exposure
-2106,1,0,,Distribution of age by device_concept_id,device_concept_id,gender_concept_id,,,,1,Device Exposure
-2110,0,0,,Number of device_exposure records outside valid observation period,,,,,,1,Observation Period
-2125,0,0,,Number of device_exposure records by device_source_concept_id,device_source_concept_id,,,,,1,Device Exposure
-2130,0,0,,Number of device_exposure records inside a valid observation period,,,,,,1,Observation Period
-2131,0,0,,Proportion of people with at least one device_exposure record outside a valid observation period,Proportion,Number of people with a device_exposure record outside a valid observation period,Number of people in device_exposure,,,1,Observation Period
-2132,0,0,,Proportion of device_exposure records outside a valid observation period,Proportion,Number of records in device_exposure outside a valid observation period,Number of device_exposure records,,,1,Observation Period
-2191,0,0,,Percentage of total persons that have at least x device exposures,device_concept_id,device_person,,,,1,Device Exposure
-2200,0,0,,Number of persons with at least one note by  note_type_concept_id,note_type_concept_id,,,,,1,Note
-2201,0,0,,"Number of note records, by note_type_concept_id",note_type_concept_id,,,,,1,Note
+ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_2_NAME,STRATUM_3_NAME,STRATUM_4_NAME,STRATUM_5_NAME,IS_DEFAULT,CATEGORY
+0,-1,,Source name,,,,,,1,General
+1,0,,Number of persons,,,,,,1,Person
+2,0,,Number of persons by gender,gender_concept_id,,,,,1,Person
+3,0,,Number of persons by year of birth,year_of_birth,,,,,1,Person
+4,0,,Number of persons by race,race_concept_id,,,,,1,Person
+5,0,,Number of persons by ethnicity,ethnicity_concept_id,,,,,1,Person
+7,0,,Number of persons with invalid provider_id,,,,,,1,Person
+8,0,,Number of persons with invalid location_id,,,,,,1,Person
+9,0,,Number of persons with invalid care_site_id,,,,,,1,Person
+10,0,,Number of all persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1,Person
+11,0,,Number of non-deceased persons by year of birth by gender,year_of_birth,gender_concept_id,,,,1,Person
+12,0,,Number of persons by race and ethnicity,race_concept_id,ethnicity_concept_id,,,,1,Person
+101,0,,"Number of persons by age, with age at first observation period",age,,,,,1,Person
+102,0,,"Number of persons by gender by age, with age at first observation period",gender_concept_id,age,,,,1,Person
+103,1,,Distribution of age at first observation period,,,,,,1,Observation Period
+104,1,,Distribution of age at first observation period by gender,gender_concept_id,,,,,1,Observation Period
+105,1,,Length of observation (days) of first observation period,,,,,,1,Observation Period
+106,1,,Length of observation (days) of first observation period by gender,gender_concept_id,,,,,1,Observation Period
+107,1,,Length of observation (days) of first observation period by age decile,age decile,,,,,1,Observation Period
+108,0,,"Number of persons by length of observation period, in 30d increments",Observation period length 30d increments,,,,,1,Observation Period
+109,0,,Number of persons with continuous observation in each year,calendar year,,,,,1,Observation Period
+110,0,,Number of persons with continuous observation in each month,calendar month,,,,,1,Observation Period
+111,0,,Number of persons by observation period start month,calendar month,,,,,1,Observation Period
+112,0,,Number of persons by observation period end month,calendar month,,,,,1,Observation Period
+113,0,,Number of persons by number of observation periods,number of observation periods,,,,,1,Observation Period
+114,0,,Number of persons with observation period before year-of-birth,,,,,,1,Observation Period
+115,0,,Number of persons with observation period end < observation period start,,,,,,1,Observation Period
+116,0,,Number of persons with at least one day of observation in each year by gender and age decile,calendar year,gender_concept_id,age decile,,,1,Observation Period
+117,0,,Number of persons with at least one day of observation in each month,calendar month,,,,,1,Observation Period
+118,0,,Number of observation periods with invalid person_id,,,,,,1,Observation Period
+119,0,,Number of observation period records by period_type_concept_id,period_type_concept_id,,,,,1,Observation Period
+200,0,,"Number of persons with at least one visit occurrence, by visit_concept_id",visit_concept_id,,,,,1,Visit Occurrence
+201,0,,"Number of visit occurrence records, by visit_concept_id",visit_concept_id,,,,,1,Visit Occurrence
+202,0,,"Number of persons by visit occurrence start month, by visit_concept_id",visit_concept_id,calendar month,,,,1,Visit Occurrence
+203,1,,Number of distinct visit occurrence concepts per person,,,,,,1,Visit Occurrence
+204,0,,"Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile",visit_concept_id,calendar year,gender_concept_id,age decile,,1,Visit Occurrence
+206,1,,Distribution of age by visit_concept_id,visit_concept_id,gender_concept_id,,,,1,Visit Occurrence
+207,0,,Number of visit records with invalid person_id,,,,,,1,Visit Occurrence
+209,0,,Number of visit records with invalid care_site_id,,,,,,1,Visit Occurrence
+210,0,,Number of visit_occurrence records outside a valid observation period,,,,,,1,Observation Period
+211,0,,Number of visit records with end date < start date,,,,,,1,Visit Occurrence
+212,0,,"Number of persons with at least one visit occurrence, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Visit Occurrence
+213,1,,Distribution of length of stay by visit_concept_id,visit_concept_id,,,,,1,Visit Occurrence
+220,0,,Number of visit occurrence records by visit occurrence start month,calendar month,,,,,1,Visit Occurrence
+221,0,,Number of persons by visit start year,calendar year,,,,,1,Visit Occurrence
+225,0,,Number of visit_occurrence records by visit_source_concept_id,visit_source_concept_id,,,,,1,Visit Occurrence
+226,0,,Number of records by domain by visit_concept_id,visit_source_concept_id,cdm_table_name,,,,1,Visit Occurrence
+230,0,,Number of visit_occurrence records inside valid observation period,,,,,,1,Observation Period
+231,0,,Proportion of people with at least one visit_occurrence record outside a valid observation period,Proportion,Number of people with a visit_occurrence record outside a valid observation period,Number of people in visit_occurrence,,,1,Observation Period
+232,0,,Proportion of visit_occurrence records outside a valid observation period,Proportion,Number of visit_occurrence records outside a valid observation period,Number of visit_occurrence records,,,1,Observation Period
+300,0,,Number of providers,,,,,,1,Provider
+301,0,,Number of providers by specialty concept_id,specialty_concept_id,,,,,1,Provider
+303,0,,Number of providers records by specialty_concept_id and visit_concept_id,specialty_concept_id,visit_concept_id,,,,1,Provider
+325,0,,Number of provider records by specialty_source_concept_id,specialty_source_concept_id,,,,,1,Provider
+400,0,,"Number of persons with at least one condition occurrence, by condition_concept_id",condition_concept_id,,,,,1,Condition Occurrence
+401,0,,"Number of condition occurrence records, by condition_concept_id",condition_concept_id,,,,,1,Condition Occurrence
+402,0,,"Number of persons by condition occurrence start month, by condition_concept_id",condition_concept_id,calendar month,,,,1,Condition Occurrence
+403,1,,Number of distinct condition occurrence concepts per person,,,,,,1,Condition Occurrence
+404,0,,"Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1,Condition Occurrence
+405,0,,"Number of condition occurrence records, by condition_concept_id by condition_type_concept_id",condition_concept_id,condition_type_concept_id,,,,1,Condition Occurrence
+406,1,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1,Condition Occurrence
+409,0,,Number of condition occurrence records with invalid person_id,,,,,,1,Condition Occurrence
+410,0,,Number of condition occurrence records outside valid observation period,,,,,,1,Observation Period
+411,0,,Number of condition occurrence records with end date < start date,,,,,,1,Condition Occurrence
+412,0,,Number of condition occurrence records with invalid provider_id,,,,,,1,Condition Occurrence
+413,0,,Number of condition occurrence records with invalid visit_id,,,,,,1,Condition Occurrence
+414,0,,"Number of condition occurrence records, by condition_status_concept_id",condition_status_concept_id,,,,,1,Condition Occurrence
+415,0,,"Number of condition occurrence records, by condition_type_concept_id",condition_type_concept_id,,,,,1,Condition Occurrence
+416,0,,"Number of condition occurrence records, by condition_status_concept_id, condition_type_concept_id",condition_status_concept_id,condition_type_concept_id,,,,1,Condition Occurrence
+420,0,,Number of condition occurrence records by condition occurrence start month,calendar month,,,,,1,Condition Occurrence
+425,0,,Number of condition_occurrence records by condition_source_concept_id,condition_source_concept_id,,,,,1,Condition Occurrence
+424,0,,Number of distinct people with co-occurring condition_occurrence condition_concept_id pairs,condition_concept_id,condition_concept_id,ranking,num_people,num_cases,0,Condition Occurrence
+430,0,,Number of condition_occurrence records inside a valid observation period,,,,,,1,Observation Period
+431,0,,Proportion of people with at least one condition_occurrence record outside a valid observation period,Proportion,Number of people with a condition_occurrence record outside a valid observation period,Number of people in condition_occurrence,,,1,Observation Period
+432,0,,Proportion of condition_occurrence records outside a valid observation period,Proportion,Number of condition_occurrence records outside a valid observation period,Number of condition_occurrence records,,,1,Observation Period
+500,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,,1,Death
+501,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,,1,Death
+502,0,,Number of persons by death month,calendar month,,,,,1,Death
+504,0,,"Number of persons with a death, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Death
+505,0,,"Number of death records, by death_type_concept_id",death_type_concept_id,,,,,1,Death
+506,1,,Distribution of age at death by gender,gender_concept_id,,,,,1,Death
+509,0,,Number of death records with invalid person_id,,,,,,1,Death
+510,0,,Number of death records outside valid observation period,,,,,,1,Observation Period
+511,1,,Distribution of time from death to last condition,,,,,,1,Death
+512,1,,Distribution of time from death to last drug,,,,,,1,Death
+513,1,,Distribution of time from death to last visit,,,,,,1,Death
+514,1,,Distribution of time from death to last procedure,,,,,,1,Death
+515,1,,Distribution of time from death to last observation,,,,,,1,Death
+525,0,,Number of death records by cause_source_concept_id,cause_source_concept_id,,,,,1,Death
+530,0,,Number of death records inside a valid observation period,,,,,,1,Observation Period
+531,0,,Proportion of people with at least one death record outside a valid observation period,Proportion,Number of people with a death record outside a valid observation period,Number of people in death,,,1,Observation Period
+532,0,,Proportion of death records that occur outside a valid observation period,Proportion,Number of records in death outside a valid observation period,Number of death records,,,1,Observation Period
+600,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
+601,0,,"Number of procedure occurrence records, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
+602,0,,"Number of persons by procedure occurrence start month, by procedure_concept_id",procedure_concept_id,calendar month,,,,1,Procedure Occurrence
+603,1,,Number of distinct procedure occurrence concepts per person,,,,,,1,Procedure Occurrence
+604,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile",procedure_concept_id,calendar year,gender_concept_id,age decile,,1,Procedure Occurrence
+605,0,,"Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id",procedure_concept_id,procedure_type_concept_id,,,,1,Procedure Occurrence
+606,1,,Distribution of age by procedure_concept_id,procedure_concept_id,gender_concept_id,,,,1,Procedure Occurrence
+609,0,,Number of procedure occurrence records with invalid person_id,,,,,,1,Procedure Occurrence
+610,0,,Number of procedure occurrence records outside valid observation period,,,,,,1,Observation Period
+612,0,,Number of procedure occurrence records with invalid provider_id,,,,,,1,Procedure Occurrence
+613,0,,Number of procedure occurrence records with invalid visit_id,,,,,,1,Procedure Occurrence
+620,0,,Number of procedure occurrence records  by procedure occurrence start month,calendar month,,,,,1,Procedure Occurrence
+625,0,,Number of procedure_occurrence records by procedure_source_concept_id,procedure_source_concept_id,,,,,1,Procedure Occurrence
+624,0,,Number of distinct people with co-occurring procedure_occurrence procedure_concept_id pairs,procedure_concept_id,procedure_concept_id,ranking,num_people,num_cases,0,Procedure Occurrence
+630,0,,Number of procedure_occurrence records inside a valid observation period,,,,,,1,Observation Period
+631,0,,Proportion of people with at least one procedure_occurrence record outside a valid observation period,Proportion,Number of people with a procedure_occurrence record outside a valid observation period,Number of people in procedure_occurrence,,,1,Observation Period
+632,0,,Proportion of procedure_occurrence records outside a valid observation period,Proportion,Number of records in procedure_occurrence outside a valid observation period,Number of procedure_occurrence records,,,1,Observation Period
+691,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,,1,Procedure Occurrence
+700,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
+701,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
+702,0,,"Number of persons by drug exposure start month, by drug_concept_id",drug_concept_id,calendar month,,,,1,Drug Exposure
+703,1,,Number of distinct drug exposure concepts per person,,,,,,1,Drug Exposure
+704,0,,"Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1,Drug Exposure
+705,0,,"Number of drug exposure records, by drug_concept_id by drug_type_concept_id",drug_concept_id,drug_type_concept_id,,,,1,Drug Exposure
+706,1,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1,Drug Exposure
+709,0,,Number of drug exposure records with invalid person_id,,,,,,1,Drug Exposure
+710,0,,Number of drug exposure records outside valid observation period,,,,,,1,Observation Period
+711,0,,Number of drug exposure records with end date < start date,,,,,,1,Drug Exposure
+712,0,,Number of drug exposure records with invalid provider_id,,,,,,1,Drug Exposure
+713,0,,Number of drug exposure records with invalid visit_id,,,,,,1,Drug Exposure
+715,1,,Distribution of days_supply by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
+716,1,,Distribution of refills by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
+717,1,,Distribution of quantity by drug_concept_id,drug_concept_id,,,,,1,Drug Exposure
+720,0,,Number of drug exposure records  by drug exposure start month,calendar month,,,,,1,Drug Exposure
+725,0,,Number of drug_exposure records by drug_source_concept_id,drug_source_concept_id,,,,,1,Drug Exposure
+724,0,,Number of distinct people with co-occurring drug_exposure drug_concept_id pairs,drug_concept_id,drug_concept_id,ranking,num_people,num_cases,0,Drug Exposure
+730,0,,Number of drug_exposure records inside a valid observation period,,,,,,1,Observation Period
+731,0,,Proportion of people with at least one drug_exposure record outside a valid observation period,Proportion,Number of people with a drug_exposure record outside a valid observation period,Number of people in drug_exposure,,,1,Observation Period
+732,0,,Proportion of drug_exposure records outside a valid observation period,Proportion,Number of records in drug_exposure outside a valid observation period,Number of drug_exposure records,,,1,Observation Period
+791,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,,1,Drug Exposure
+800,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,,1,Observation
+801,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,,1,Observation
+802,0,,"Number of persons by observation occurrence start month, by observation_concept_id",observation_concept_id,calendar month,,,,1,Observation
+803,1,,Number of distinct observation occurrence concepts per person,,,,,,1,Observation
+804,0,,"Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile",observation_concept_id,calendar year,gender_concept_id,age decile,,1,Observation
+805,0,,"Number of observation occurrence records, by observation_concept_id by observation_type_concept_id",observation_concept_id,observation_type_concept_id,,,,1,Observation
+806,1,,Distribution of age by observation_concept_id,observation_concept_id,gender_concept_id,,,,1,Observation
+807,0,,"Number of observation occurrence records, by observation_concept_id and unit_concept_id",observation_concept_id,unit_concept_id,,,,1,Observation
+809,0,,Number of observation records with invalid person_id,,,,,,1,Observation
+810,0,,Number of observation records outside valid observation period,,,,,,1,Observation Period
+812,0,,Number of observation records with invalid provider_id,,,,,,1,Observation
+813,0,,Number of observation records with invalid visit_id,,,,,,1,Observation
+814,0,,"Number of observation records with no value (numeric, string, or concept)",,,,,,1,Observation
+815,1,,"Distribution of numeric values, by observation_concept_id and unit_concept_id",,,,,,1,Observation
+820,0,,Number of observation records  by observation start month,calendar month,,,,,1,Observation
+822,0,,"Number of observation records, by observation_concept_id and value_as_concept_id",observation_concept_id,value_as_concept_id,,,,1,Observation
+823,0,,"Number of observation records, by observation_concept_id and qualifier_concept_id",observation_concept_id,qualifier_concept_id,,,,1,Observation
+824,0,,Number of distinct people with co-occurring observation observation_concept_id pairs,observation_concept_id,observation_concept_id,ranking,num_people,num_cases,0,Observation
+825,0,,Number of observation records by observation_source_concept_id,observation_source_concept_id,,,,,1,Observation
+826,0,,Number of observation records by value_as_concept_id,value_as_concept_id,,,,,1,Observation
+827,0,,Number of observation records by unit_concept_id,unit_as_concept_id,,,,,1,Observation
+830,0,,Number of observation records inside a valid observation period,,,,,,1,Observation Period
+831,0,,Proportion of people with at least one observation record outside a valid observation period,Proportion,Number of people with a observation record outside a valid observation period,Number of people in observation,,,1,Observation Period
+832,0,,Proportion of observation records outside a valid observation period,Proportion,Number of records in observation outside a valid observation period,Number of observation records,,,1,Observation Period
+891,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,,1,Observation
+900,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
+901,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
+902,0,,"Number of persons by drug era start month, by drug_concept_id",drug_concept_id,calendar month,,,,1,Drug Era
+903,1,,Number of distinct drug era concepts per person,,,,,,1,Drug Era
+904,0,,"Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile",drug_concept_id,calendar year,gender_concept_id,age decile,,1,Drug Era
+906,1,,Distribution of age by drug_concept_id,drug_concept_id,gender_concept_id,,,,1,Drug Era
+907,1,,"Distribution of drug era length, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
+908,0,,Number of drug eras without valid person,,,,,,1,Drug Era
+910,0,,Number of drug_era records outside valid observation period,,,,,,1,Observation Period
+911,0,,Number of drug eras with end date < start date,,,,,,1,Drug Era
+920,0,,Number of drug era records by drug era start month,calendar month,,,,,1,Drug Era
+930,0,,Number of drug_era records inside a valid observation period,,,,,,1,Observation Period
+931,0,,Proportion of people with at least one drug_era record outside a valid observation period,Proportion,Number of people with a drug_era record outside a valid observation period,Number of people in drug_era,,,1,Observation Period
+932,0,,Proportion of drug_era records outside a valid observation period,Proportion,Number of records in drug_era outside a valid observation period,Number of drug_era records,,,1,Observation Period
+1000,0,,"Number of persons with at least one condition era, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
+1001,0,,"Number of condition era records, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
+1002,0,,"Number of persons by condition era start month, by condition_concept_id",condition_concept_id,calendar month,,,,1,Condition Era
+1003,1,,Number of distinct condition era concepts per person,,,,,,1,Condition Era
+1004,0,,"Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile",condition_concept_id,calendar year,gender_concept_id,age decile,,1,Condition Era
+1006,1,,Distribution of age by condition_concept_id,condition_concept_id,gender_concept_id,,,,1,Condition Era
+1007,1,,"Distribution of condition era length, by condition_concept_id",condition_concept_id,,,,,1,Condition Era
+1008,0,,Number of condition eras without valid person,,,,,,1,Condition Era
+1010,0,,Number of condition_era records outside a valid observation period,,,,,,1,Observation Period
+1011,0,,Number of condition eras with end date < start date,,,,,,1,Condition Era
+1020,0,,Number of condition era records by condition era start month,calendar month,,,,,1,Condition Era
+1030,0,,Number of condition_era records inside a valid observation period,,,,,,1,Observation Period
+1031,0,,Proportion of people with at least one condition_era record outside a valid observation period,Proportion,Number of people with a condition_era record outside a valid observation period,Number of people in condition_era,,,1,Observation Period
+1032,0,,Proportion of condition_era records outside a valid observation period,Proportion,Number of records in condition_era outside a valid observation period,Number of condition_era records,,,1,Observation Period
+1100,0,,Number of persons by location 3-digit zip,3-digit zip,,,,,1,Location
+1101,0,,Number of persons by location state,state,,,,,1,Location
+1102,0,,Number of care sites by location 3-digit zip,3-digit zip,,,,,1,Location
+1103,0,,Number of care sites by location state,state,,,,,1,Location
+1200,0,,Number of persons by place of service,place_of_service_concept_id,,,,,1,Care Site
+1201,0,,Number of visits by place of service,place_of_service_concept_id,,,,,1,Care Site
+1202,0,,Number of care sites by place of service,place_of_service_concept_id,,,,,1,Care Site
+1203,0,,Number of visits by place of service discharge type,discharge_to_concept_id,,,,,1,Care Site
+1300,0,,"Number of persons with at least one visit detail, by visit_detail_concept_id",visit_detail_concept_id,,,,,1,Visit Detail
+1301,0,,"Number of visit detail records, by visit_detail_concept_id",visit_detail_concept_id,,,,,1,Visit Detail
+1302,0,,"Number of persons by visit detail start month, by visit_detail_concept_id",visit_detail_concept_id,calendar month,,,,1,Visit Detail
+1303,1,,Number of distinct visit detail concepts per person,,,,,,1,Visit Detail
+1304,0,,"Number of persons with at least one visit detail, by visit_detail_concept_id by calendar year by gender by age decile",visit_detail_concept_id,calendar year,gender_concept_id,age decile,,1,Visit Detail
+1306,1,,Distribution of age by visit_detail_concept_id,visit_detail_concept_id,gender_concept_id,,,,1,Visit Detail
+1307,0,,Number of visit records with invalid person_id,,,,,,1,Visit Detail
+1309,0,,Number of visit_detail records with invalid care_site_id,,,,,,1,Visit Detail
+1310,0,,Number of visit_detail records outside a valid observation period,,,,,,1,Observation Period
+1311,0,,Number of visit_detail records with end date < start date,,,,,,1,Visit Detail
+1312,0,,"Number of persons with at least one visit detail, by calendar year by gender by age decile",calendar year,gender_concept_id,age decile,,,1,Visit Detail
+1313,1,,Distribution of length of stay by visit_detail_concept_id,visit_detail_concept_id,,,,,1,Visit Detail
+1320,0,,Number of visit detail records by visit detail start month,calendar month,,,,,1,Visit Detail
+1321,0,,Number of persons by visit start year,calendar year,,,,,1,Visit Detail
+1325,0,,Number of visit_detail records by visit_detail_source_concept_id,visit_detail_source_concept_id,,,,,1,Visit Detail
+1326,0,,Number of records by domain by visit_detail_concept_id,visit_detail_source_concept_id,cdm_table_name,,,,1,Visit Detail
+1330,0,,Number of visit_detail records inside a valid observation period,,,,,,1,Observation Period
+1331,0,,Proportion of people with at least one visit_detail record outside a valid observation period,Proportion,Number of people with a visit_detail record outside a valid observation period,Number of people in visit_detail,,,1,Observation Period
+1332,0,,Proportion of visit_detail records outside a valid observation period,Proportion,Number of records in visit_detail outside a valid observation period,Number of visit_detail records,,,1,Observation Period
+1406,1,,Length of payer plan (days) of first payer plan period by gender,gender_concept_id,,,,,1,Payer Plan Period
+1407,1,,Length of payer plan (days) of first payer plan period by age decile,age_decile,,,,,1,Payer Plan Period
+1408,0,,"Number of persons by length of payer plan period, in 30d increments",payer plan period length 30d increments,,,,,1,Payer Plan Period
+1409,0,,Number of persons with continuous payer plan in each year,calendar year,,,,,1,Payer Plan Period
+1410,0,,Number of persons with continuous payer plan in each month,calendar month,,,,,1,Payer Plan Period
+1411,0,,Number of persons by payer plan period start month,calendar month,,,,,1,Payer Plan Period
+1412,0,,Number of persons by payer plan period end month,calendar month,,,,,1,Payer Plan Period
+1413,0,,Number of persons by number of payer plan periods,number of payer plan periods,,,,,1,Payer Plan Period
+1414,0,,Number of persons with payer plan period before year-of-birth,,,,,,1,Payer Plan Period
+1415,0,,Number of persons with payer plan period end < payer plan period start,,,,,,1,Payer Plan Period
+1425,0,,Number of payer_plan_period records by payer_source_concept_id,payer_source_concept_id,,,,,1,Payer Plan Period
+1502,1,paid_patient_copay,"Distribution of paid_patient_copay, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1503,1,paid_patient_coinsurance,"Distribution of paid_patient_coinsurance, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1504,1,paid_patient_deductible,"Distribution of paid_patient_deductible, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1505,1,paid_by_payer,"Distribution of paid_by_payer, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1506,1,paid_by_primary,"Distribution of paid_by_primary, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1507,1,paid_by_patient,"Distribution of paid_by_patient, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1508,1,total_paid,"Distribution of total_paid, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1509,1,paid_ingredient_cost,"Distribution of paid_ingredient_cost, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1510,1,paid_dispensing_fee,"Distribution of paid_dispensing_fee, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1511,1,total_cost,"Distribution of total_cost, by drug_concept_id",drug_concept_id,,,,,0,Cost
+1602,1,paid_patient_copay,"Distribution of paid_patient_copay, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1603,1,paid_patient_coinsurance,"Distribution of paid_patient_coinsurance, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1604,1,paid_patient_deductible,"Distribution of paid_patient_deductible, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1605,1,paid_by_payer,"Distribution of paid_by_payer, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1606,1,paid_by_primary,"Distribution of paid_by_primary, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1607,1,paid_by_patient,"Distribution of paid_by_patient, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1608,1,total_paid,"Distribution of total paid, by procedure_concept_id",procedure_concept_id,,,,,0,Cost
+1610,0,,Number of records by revenue_code_concept_id,revenue_code_concept_id,,,,,0,Cost
+1800,0,,"Number of persons with at least one measurement occurrence, by measurement_concept_id",measurement_concept_id,,,,,1,Measurement
+1801,0,,"Number of measurement occurrence records, by measurement_concept_id",measurement_concept_id,,,,,1,Measurement
+1802,0,,"Number of persons by measurement occurrence start month, by measurement_concept_id",measurement_concept_id,calendar month,,,,1,Measurement
+1803,1,,Number of distinct mesurement occurrence concepts per person,,,,,,1,Measurement
+1804,0,,"Number of persons with at least one mesurement  occurrence, by measurement_concept_id by calendar year by gender by age decile",measurement_concept_id,calendar year,gender_concept_id,age decile,,1,Measurement
+1805,0,,"Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id",measurement_concept_id,measurement_type_concept_id,,,,1,Measurement
+1806,1,,Distribution of age by measurement_concept_id,measurement_concept_id,gender_concept_id,,,,1,Measurement
+1807,0,,"Number of measurement occurrence records, by measurement_concept_id and unit_concept_id",measurement_concept_id,unit_concept_id,,,,1,Measurement
+1809,0,,Number of measurement records with invalid person_id,,,,,,1,Measurement
+1810,0,,Number of measurement records outside valid observation period,,,,,,1,Observation Period
+1812,0,,Number of measurement records with invalid provider_id,,,,,,1,Measurement
+1813,0,,Number of measurement records with invalid visit_id,,,,,,1,Measurement
+1814,0,,"Number of measurement records with no value (numeric, string, or concept)",,,,,,1,Measurement
+1815,1,,"Distribution of numeric values, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
+1816,1,,"Distribution of low range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
+1817,1,,"Distribution of high range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
+1818,0,,"Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id",,,,,,1,Measurement
+1820,0,,Number of measurement records  by measurement start month,calendar month,,,,,1,Measurement
+1821,0,,Number of measurement records with no numeric value,,,,,,1,Measurement
+1822,0,,"Number of measurement records, by measurement_concept_id and value_as_concept_id",measurement_concept_id,value_as_concept_id,,,,1,Measurement
+1823,0,,"Number of measurement records, by measurement_concept_id and operator_concept_id",measurement_concept_id,operator_concept_id,,,,1,Measurement
+1824,0,,Number of distinct people with co-occurring measurement measurement_concept_id pairs,measurement_concept_id,measurement_concept_id,ranking,num_people,num_cases,0,Measurement
+1825,0,,Number of measurement records by measurement_source_concept_id,measurement_source_concept_id,,,,,1,Measurement
+1826,0,,Number of measurement records by value_as_concept_id,value_as_concept_id,,,,,1,Measurement
+1827,0,,Number of measurement records by unit_concept_id,unit_as_concept_id,,,,,1,Measurement
+1830,0,,Number of visit_detail records inside a valid observation period,,,,,,1,Observation Period
+1831,0,,Proportion of people with at least one measurement record outside a valid observation period,Proportion,Number of people with a measurement record outside a valid observation period,Number of people in measurement,,,1,Observation Period
+1832,0,,Proportion of measurement records outside a valid observation period,Proportion,Number of records in measurement outside a valid observation period,Number of measurement records,,,1,Observation Period
+1833,0,,Proportion of measurement records inside a valid observation period and without a value,measurement_concept_id,Number of measurement records with no value for the given measurement_concept_id,proportion,,,1,Measurement
+1891,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,,1,Measurement
+1900,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,,1,Completeness
+2000,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,,1,Completeness
+2001,0,,Number of patients with at least 1 Dx and 1 Proc,,,,,,1,Completeness
+2002,0,,"Number of patients with at least 1 Meas, 1 Dx and 1 Rx",,,,,,1,Completeness
+2003,0,,Number of patients with at least 1 Visit,,,,,,1,Completeness
+2004,0,,Number of distinct patients that overlap between specific domains,domain_bit_string,proportion_of_overlap,,,,1,Completeness
+2100,0,,"Number of persons with at least one device exposure, by device_concept_id",device_concept_id,,,,,1,Completeness
+2101,0,,"Number of device exposure records, by device_concept_id",device_concept_id,,,,,1,Device Exposure
+2102,0,,"Number of persons by device records  start month, by device_concept_id",device_concept_id,calendar month,,,,1,Device Exposure
+2104,0,,"Number of persons with at least one device exposure, by device_concept_id by calendar year by gender by age decile",device_concept_id,calendar year,gender_concept_id,age decile,,1,Device Exposure
+2105,0,,"Number of device exposure records, by device_concept_id by device_type_concept_id",device_concept_id,device_type_concept_id,,,,1,Device Exposure
+2106,1,,Distribution of age by device_concept_id,device_concept_id,gender_concept_id,,,,1,Device Exposure
+2110,0,,Number of device_exposure records outside valid observation period,,,,,,1,Observation Period
+2125,0,,Number of device_exposure records by device_source_concept_id,device_source_concept_id,,,,,1,Device Exposure
+2130,0,,Number of device_exposure records inside a valid observation period,,,,,,1,Observation Period
+2131,0,,Proportion of people with at least one device_exposure record outside a valid observation period,Proportion,Number of people with a device_exposure record outside a valid observation period,Number of people in device_exposure,,,1,Observation Period
+2132,0,,Proportion of device_exposure records outside a valid observation period,Proportion,Number of records in device_exposure outside a valid observation period,Number of device_exposure records,,,1,Observation Period
+2191,0,,Percentage of total persons that have at least x device exposures,device_concept_id,device_person,,,,1,Device Exposure
+2200,0,,Number of persons with at least one note by  note_type_concept_id,note_type_concept_id,,,,,1,Note
+2201,0,,"Number of note records, by note_type_concept_id",note_type_concept_id,,,,,1,Note


### PR DESCRIPTION
Successfully tested against CDM v5.3 on redshift. 
Here's a test case:

IN YOUR DATABASE'S RESULTS SCHEMA

```DELETE FROM ACHILLES_RESULTS WHERE ANALYSIS_ID = 402;```

FROM R:
```r
> ma <- Achilles::listMissingAnalyses(connectionDetails,resultsDatabaseSchema)
> ma[ma$ANALYSIS_ID==402,]
ANALYSIS_ID  DISTRIBUTION  CATEGORY              IS_DEFAULT  ANALYSIS_NAME
402          0             Condition Occurrence  1           Number of persons by condition occurrence start month, by condition_concept_id


Achilles::runMissingAnalyses(
  connectionDetails = connectionDetails,
  cdmDatabaseSchema = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema,
  outputFolder = "D:/sandbox/Achilles")

> ma <- Achilles::listMissingAnalyses(connectionDetails,resultsDatabaseSchema)
> ma[ma$ANALYSIS_ID==402,]
[1] ANALYSIS_ID   DISTRIBUTION  CATEGORY      IS_DEFAULT    ANALYSIS_NAME
<0 rows> (or 0-length row.names)
```

NB: Analyses that result in "no data found" in the CDM will still be "missing" even after runMissingAnalyses is run, which is why a common analysis_id like 402 was chosen to test with.
