### PR TITLE
Fixes #665

### DIFF
--- a/inst/sql/sql_server/export/achillesheel/sqlAchillesHeel.sql
+++ b/inst/sql/sql_server/export/achillesheel/sqlAchillesHeel.sql
@@ -1,3 +1,0 @@
-select analysis_id as AttributeName, ACHILLES_HEEL_warning as AttributeValue
-from @results_database_schema.ACHILLES_HEEL_results
-order by case when left(ACHILLES_HEEL_warning,5) = 'Error' then 1 else 2 end, analysis_id

--- a/inst/sql/sql_server/export/condition/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export/condition/sqlAgeAtFirstDiagnosis.sql
@@ -8,7 +8,7 @@
   	ard1.p90_value as p90_value,
   	ard1.max_value as max_value
   from (
-    select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+    select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
     FROM @results_database_schema.achilles_results_dist
     where analysis_id = 406
     GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/condition/sqlConditionTable.sql
+++ b/inst/sql/sql_server/export/condition/sqlConditionTable.sql
@@ -4,9 +4,9 @@ select concept.concept_id,
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 400 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 400 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 401 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 401 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/condition/sqlConditionTreemap.sql
+++ b/inst/sql/sql_server/export/condition/sqlConditionTreemap.sql
@@ -7,9 +7,9 @@ select   concept_hierarchy.concept_id,
   ar1.count_value as num_persons, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 400 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 400 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 401 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 401 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/condition/sqlConditionsByType.sql
+++ b/inst/sql/sql_server/export/condition/sqlConditionsByType.sql
@@ -1,5 +1,5 @@
 with summary as (
-  select cast(stratum_1 as int) condition_concept_id, cast(stratum_2 as int) condition_type_concept_id, count_value, sum(count_value) s_count_value
+  select cast(stratum_1 as bigint) condition_concept_id, cast(stratum_2 as bigint) condition_type_concept_id, count_value, sum(count_value) s_count_value
   FROM  @results_database_schema.achilles_results
   where analysis_id = 405
   GROUP BY stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/condition/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/condition/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 404
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/condition/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/condition/sqlPrevalenceByMonth.sql
@@ -3,9 +3,9 @@
   	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
   	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
   from 
-  	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 402 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+  	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 402 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
   	inner join
-  	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
+  	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
   	on num.stratum_2 = denom.stratum_1  --calendar year
   	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
-ORDER BY CAST(num.stratum_2 as INT)
+ORDER BY CAST(num.stratum_2 as BIGINT)

--- a/inst/sql/sql_server/export/conditionera/sqlAgeAtFirstDiagnosis.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlAgeAtFirstDiagnosis.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1006 and count_value > 0
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/conditionera/sqlConditionEraTable.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlConditionEraTable.sql
@@ -5,15 +5,15 @@ select concept.concept_id,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person,
 	era.p25_value, era.median_value, era.p75_value
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1000 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1000 GROUP BY analysis_id, stratum_1, count_value) ar1
 	join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1001 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1001 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	join
 	(select concept_id, concept_name from @vocab_database_schema.concept) concept 
 	on concept.concept_id = ar1.stratum_1
 	join 
-	(select cast(stratum_1 as int) concept_id, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value FROM @results_database_schema.achilles_results_dist where analysis_id = 1007) era
+	(select cast(stratum_1 as bigint) concept_id, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value FROM @results_database_schema.achilles_results_dist where analysis_id = 1007) era
 	on era.concept_id = ar1.stratum_1,
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom
 order by ar1.count_value desc

--- a/inst/sql/sql_server/export/conditionera/sqlConditionEraTreemap.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlConditionEraTreemap.sql
@@ -7,9 +7,9 @@ select 	concept_hierarchy.concept_id,
 	ar1.count_value as num_persons, 
 	ROUND(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	ROUND(ar2.avg_value,5) as length_of_era
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1000 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1000 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, avg_value from @results_database_schema.achilles_results_dist where analysis_id = 1007 GROUP BY analysis_id, stratum_1, avg_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, avg_value from @results_database_schema.achilles_results_dist where analysis_id = 1007 GROUP BY analysis_id, stratum_1, avg_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
   (

--- a/inst/sql/sql_server/export/conditionera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlLengthOfEra.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1007 and count_value > 0
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/conditionera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlPrevalenceByGenderAgeYear.sql
@@ -11,14 +11,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 1004
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/conditionera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/conditionera/sqlPrevalenceByMonth.sql
@@ -2,8 +2,8 @@ select c1.concept_id as concept_id,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 1002 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 1002 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
 	on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/datadensity/recordsperperson.sql
+++ b/inst/sql/sql_server/export/datadensity/recordsperperson.sql
@@ -3,27 +3,27 @@ select t1.table_name as SERIES_NAME,
 	round(1.0*t1.count_value/denom.count_value,5) as Y_RECORD_COUNT
 from
 (
-	select 'Visit occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 220 GROUP BY analysis_id, stratum_1, count_value
+	select 'Visit occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 220 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Condition occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 420 GROUP BY analysis_id, stratum_1, count_value
+	select 'Condition occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 420 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Death' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value
+	select 'Death' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Procedure occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 620 GROUP BY analysis_id, stratum_1, count_value
+	select 'Procedure occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 620 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Drug exposure' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 720 GROUP BY analysis_id, stratum_1, count_value
+	select 'Drug exposure' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 720 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Observation' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 820 GROUP BY analysis_id, stratum_1, count_value
+	select 'Observation' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 820 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Drug era' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 920 GROUP BY analysis_id, stratum_1, count_value
+	select 'Drug era' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 920 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Condition era' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1020 GROUP BY analysis_id, stratum_1, count_value
+	select 'Condition era' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1020 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Observation period' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 111 GROUP BY analysis_id, stratum_1, count_value
+	select 'Observation period' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 111 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Measurement' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1820 GROUP BY analysis_id, stratum_1, count_value
+	select 'Measurement' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1820 GROUP BY analysis_id, stratum_1, count_value
 ) t1
 inner join
-(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
+(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
 on t1.stratum_1 = denom.stratum_1
 ORDER BY SERIES_NAME, t1.stratum_1

--- a/inst/sql/sql_server/export/datadensity/totalrecords.sql
+++ b/inst/sql/sql_server/export/datadensity/totalrecords.sql
@@ -3,26 +3,26 @@ select table_name as SERIES_NAME,
 	count_value as Y_RECORD_COUNT
 from
 (
-	select 'Visit occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 220 GROUP BY analysis_id, stratum_1, count_value
+	select 'Visit occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 220 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Condition occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 420 GROUP BY analysis_id, stratum_1, count_value
+	select 'Condition occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 420 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Death' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value
+	select 'Death' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Procedure occurrence' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 620 GROUP BY analysis_id, stratum_1, count_value
+	select 'Procedure occurrence' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 620 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Drug exposure' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 720 GROUP BY analysis_id, stratum_1, count_value
+	select 'Drug exposure' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 720 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Observation' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 820 GROUP BY analysis_id, stratum_1, count_value
+	select 'Observation' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 820 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Drug era' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 920 GROUP BY analysis_id, stratum_1, count_value
+	select 'Drug era' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 920 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Condition era' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1020 GROUP BY analysis_id, stratum_1, count_value
+	select 'Condition era' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1020 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Person' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 111 GROUP BY analysis_id, stratum_1, count_value
+	select 'Person' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 111 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Measurement' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1820 GROUP BY analysis_id, stratum_1, count_value
+	select 'Measurement' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1820 GROUP BY analysis_id, stratum_1, count_value
 	union all
-	select 'Device' as table_name, CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2120 GROUP BY analysis_id, stratum_1, count_value	
+	select 'Device' as table_name, CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2120 GROUP BY analysis_id, stratum_1, count_value	
 ) t1
 ORDER BY SERIES_NAME, stratum_1

--- a/inst/sql/sql_server/export/death/sqlAgeAtDeath.sql
+++ b/inst/sql/sql_server/export/death/sqlAgeAtDeath.sql
@@ -7,7 +7,7 @@ select c2.concept_name as category,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
   from (
-    select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+    select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
     FROM @results_database_schema.achilles_results_dist
     where analysis_id = 506
     GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/death/sqlDeathByType.sql
+++ b/inst/sql/sql_server/export/death/sqlDeathByType.sql
@@ -2,7 +2,7 @@ select c2.concept_id as concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, count_value
+  select cast(stratum_1 as bigint) stratum_1, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 505
   GROUP BY analysis_id, stratum_1, count_value

--- a/inst/sql/sql_server/export/death/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/death/sqlPrevalenceByGenderAgeYear.sql
@@ -5,9 +5,9 @@ select concat(cast(num.stratum_3 * 10 as varchar),
 	num.stratum_1 as x_calendar_year,   -- calendar year, note, there could be blanks
 	ROUND(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, count_value from @results_database_schema.achilles_results where analysis_id = 504 GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, count_value from @results_database_schema.achilles_results where analysis_id = 504 GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, count_value from @results_database_schema.achilles_results where analysis_id = 116 GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value) denom on num.stratum_1 = denom.stratum_1  --calendar year
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, count_value from @results_database_schema.achilles_results where analysis_id = 116 GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value) denom on num.stratum_1 = denom.stratum_1  --calendar year
 		and num.stratum_2 = denom.stratum_2 --gender
 		and num.stratum_3 = denom.stratum_3 --age decile
 	inner join @vocab_database_schema.concept c2 on num.stratum_2 = c2.concept_id

--- a/inst/sql/sql_server/export/death/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/death/sqlPrevalenceByMonth.sql
@@ -1,7 +1,7 @@
 select num.stratum_1 as x_calendar_month,   -- calendar year, note, there could be blanks
 	1000*(1.0*num.count_value/denom.count_value) as y_prevalence_1000pp  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 502 GROUP BY analysis_id, stratum_1, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_1 = denom.stratum_1  --calendar year
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_1 = denom.stratum_1  --calendar year
 

--- a/inst/sql/sql_server/export/device/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export/device/sqlAgeAtFirstExposure.sql
@@ -8,7 +8,7 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 2106
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/device/sqlDeviceTable.sql
+++ b/inst/sql/sql_server/export/device/sqlDeviceTable.sql
@@ -4,9 +4,9 @@ select concept.concept_id,
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2100 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2100 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2101 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 2101 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/device/sqlDevicesByType.sql
+++ b/inst/sql/sql_server/export/device/sqlDevicesByType.sql
@@ -4,7 +4,7 @@ select c1.concept_id as OBSERVATION_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 2105
   GROUP BY analysis_id, stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/device/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export/device/sqlFrequencyDistribution.sql
@@ -1,10 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as bigint) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom,
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value 
 	from @results_database_schema.achilles_results
 	where analysis_id = 2191) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/device/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/device/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 2104
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/device/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/device/sqlPrevalenceByMonth.sql
@@ -3,8 +3,8 @@ select c1.concept_id as CONCEPT_ID,  --all rows for all concepts, but you may sp
 	num.stratum_2 as X_CALENDAR_MONTH,   -- calendar year, note, there could be blanks
 	round(1000*(1.0*num.count_value/denom.count_value),5) as Y_PREVALENCE_1000PP  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 2102 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 2102 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 

--- a/inst/sql/sql_server/export/drug/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export/drug/sqlAgeAtFirstExposure.sql
@@ -8,7 +8,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-    select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+    select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
     FROM @results_database_schema.achilles_results_dist
     where analysis_id = 706 and count_value > 0
     GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drug/sqlDaysSupplyDistribution.sql
+++ b/inst/sql/sql_server/export/drug/sqlDaysSupplyDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 715 and count_value > 0
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drug/sqlDomainDrugStratification.sql
+++ b/inst/sql/sql_server/export/drug/sqlDomainDrugStratification.sql
@@ -1,5 +1,5 @@
 select stratum_2 concept_id, concept_name, sum(count_value) record_count 
 from @results_database_schema.achilles_results ar
-join @vocab_database_schema.concept c on c.concept_id = cast(ar.stratum_2 as int)
+join @vocab_database_schema.concept c on c.concept_id = cast(ar.stratum_2 as bigint)
 where analysis_id = 705
 group by stratum_2,concept_name;

--- a/inst/sql/sql_server/export/drug/sqlDrugTable.sql
+++ b/inst/sql/sql_server/export/drug/sqlDrugTable.sql
@@ -4,9 +4,9 @@ select concept.concept_id,
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 700 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 700 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 701 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 701 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/drug/sqlDrugTreemap.sql
+++ b/inst/sql/sql_server/export/drug/sqlDrugTreemap.sql
@@ -7,9 +7,9 @@ select 	concept_hierarchy.concept_id,
 	ar1.count_value as num_persons, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 700 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 700 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 701 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 701 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/drug/sqlDrugsByType.sql
+++ b/inst/sql/sql_server/export/drug/sqlDrugsByType.sql
@@ -3,7 +3,7 @@ select c1.concept_id as drug_concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   FROM @results_database_schema.achilles_results
   where analysis_id = 705
   GROUP BY analysis_id, stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/drug/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export/drug/sqlFrequencyDistribution.sql
@@ -1,10 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as bigint) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom,
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value 
 	from @results_database_schema.achilles_results
 	where analysis_id = 791) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/drug/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/drug/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 704
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/drug/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/drug/sqlPrevalenceByMonth.sql
@@ -3,8 +3,8 @@ select c1.concept_id as concept_id,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 702 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 702 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
 	  on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/drug/sqlQuantityDistribution.sql
+++ b/inst/sql/sql_server/export/drug/sqlQuantityDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 717 and count_value > 0
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drug/sqlRefillsDistribution.sql
+++ b/inst/sql/sql_server/export/drug/sqlRefillsDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as drug_concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 716 and count_value > 0
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drugera/sqlAgeAtFirstExposure.sql
+++ b/inst/sql/sql_server/export/drugera/sqlAgeAtFirstExposure.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 906 and count_value > 0
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drugera/sqlDrugEraTable.sql
+++ b/inst/sql/sql_server/export/drugera/sqlDrugEraTable.sql
@@ -5,15 +5,15 @@ select concept.concept_id,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person,
 	era.p25_value, era.median_value, era.p75_value
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 900 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 900 GROUP BY analysis_id, stratum_1, count_value) ar1
 	join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 901 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 901 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	join
 	(select concept_id, concept_name from @vocab_database_schema.concept) concept 
 	on concept.concept_id = ar1.stratum_1
 	join 
-	(select cast(stratum_1 as int) concept_id, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value FROM @results_database_schema.achilles_results_dist where analysis_id = 907) era
+	(select cast(stratum_1 as bigint) concept_id, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value FROM @results_database_schema.achilles_results_dist where analysis_id = 907) era
 	on era.concept_id = ar1.stratum_1,
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom
 order by ar1.count_value desc

--- a/inst/sql/sql_server/export/drugera/sqlDrugEraTreemap.sql
+++ b/inst/sql/sql_server/export/drugera/sqlDrugEraTreemap.sql
@@ -6,9 +6,9 @@ select concept_hierarchy.rxnorm_ingredient_concept_id concept_id,
 	ar1.count_value as num_persons, 
 	1.0*ar1.count_value / denom.count_value as percent_persons,
 	ar2.avg_value as length_of_era
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 900 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 900 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, avg_value from @results_database_schema.achilles_results_dist where analysis_id = 907 GROUP BY analysis_id, stratum_1, avg_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, avg_value from @results_database_schema.achilles_results_dist where analysis_id = 907 GROUP BY analysis_id, stratum_1, avg_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/drugera/sqlLengthOfEra.sql
+++ b/inst/sql/sql_server/export/drugera/sqlLengthOfEra.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 907 and count_value > 0
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/drugera/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/drugera/sqlPrevalenceByGenderAgeYear.sql
@@ -11,14 +11,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 904
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/drugera/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/drugera/sqlPrevalenceByMonth.sql
@@ -2,8 +2,8 @@ select c1.concept_id as concept_id,
 	num.stratum_2 as x_calendar_month,
 	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 902 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 902 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom
 	on num.stratum_2 = denom.stratum_1  
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/measurement/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export/measurement/sqlAgeAtFirstOccurrence.sql
@@ -8,7 +8,7 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1806
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/measurement/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export/measurement/sqlFrequencyDistribution.sql
@@ -1,10 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as bigint) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom,
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value 
 	from @results_database_schema.achilles_results
 	where analysis_id = 1891) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/measurement/sqlLowerLimitDistribution.sql
+++ b/inst/sql/sql_server/export/measurement/sqlLowerLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1816 and count_value > 0
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/measurement/sqlMeasurementTable.sql
+++ b/inst/sql/sql_server/export/measurement/sqlMeasurementTable.sql
@@ -5,12 +5,12 @@ select concept.concept_id,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person,
 	ar3.stratum_3 as percent_missing_values
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1800 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1800 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1801 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1801 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	left join
-	(select cast(stratum_1 as int) stratum_1, round(cast(stratum_3 as float),4) as stratum_3 from @results_database_schema.achilles_results where analysis_id = 1833) ar3
+	(select cast(stratum_1 as bigint) stratum_1, round(cast(stratum_3 as float),4) as stratum_3 from @results_database_schema.achilles_results where analysis_id = 1833) ar3
 	on ar2.stratum_1 = ar3.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/measurement/sqlMeasurementTreemap.sql
+++ b/inst/sql/sql_server/export/measurement/sqlMeasurementTreemap.sql
@@ -6,9 +6,9 @@ select 	concept_hierarchy.concept_id,
 	ar1.count_value as num_persons, 
 	1.0*ar1.count_value / denom.count_value as percent_persons,
 	1.0*ar2.count_value / ar1.count_value as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1800 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1800 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1801 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 1801 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/measurement/sqlMeasurementValueDistribution.sql
+++ b/inst/sql/sql_server/export/measurement/sqlMeasurementValueDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1815 and count_value > 0
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/measurement/sqlMeasurementsByType.sql
+++ b/inst/sql/sql_server/export/measurement/sqlMeasurementsByType.sql
@@ -4,7 +4,7 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   FROM @results_database_schema.achilles_results
   where analysis_id = 1805
   GROUP BY analysis_id, stratum_1, stratum_2, count_value 

--- a/inst/sql/sql_server/export/measurement/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/measurement/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 1804
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/measurement/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/measurement/sqlPrevalenceByMonth.sql
@@ -3,8 +3,8 @@ select c1.concept_id as CONCEPT_ID,  --all rows for all concepts, but you may sp
 	num.stratum_2 as X_CALENDAR_MONTH,   -- calendar year, note, there could be blanks
 	round(1000*(1.0*num.count_value/denom.count_value),5) as Y_PREVALENCE_1000PP  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 1802 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 1802 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 

--- a/inst/sql/sql_server/export/measurement/sqlRecordsByUnit.sql
+++ b/inst/sql/sql_server/export/measurement/sqlRecordsByUnit.sql
@@ -4,7 +4,7 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   FROM @results_database_schema.achilles_results
   where analysis_id = 1807
   GROUP BY analysis_id, stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/measurement/sqlUpperLimitDistribution.sql
+++ b/inst/sql/sql_server/export/measurement/sqlUpperLimitDistribution.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as P90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 1817 and count_value > 0
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/measurement/sqlValuesRelativeToNorm.sql
+++ b/inst/sql/sql_server/export/measurement/sqlValuesRelativeToNorm.sql
@@ -4,7 +4,7 @@ select c1.concept_id as MEASUREMENT_CONCEPT_ID,
 	concat(c2.concept_name, ': ', ar1.stratum_3) as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, stratum_3, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, stratum_3, count_value
   FROM @results_database_schema.achilles_results
   where analysis_id = 1818
   GROUP BY analysis_id, stratum_1, stratum_2, stratum_3, count_value

--- a/inst/sql/sql_server/export/observation/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export/observation/sqlAgeAtFirstOccurrence.sql
@@ -8,7 +8,7 @@ select c1.concept_id as CONCEPT_ID,
 	ard1.p90_value as P90_VALUE,
 	ard1.max_value as MAX_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 806
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/observation/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export/observation/sqlFrequencyDistribution.sql
@@ -1,10 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as bigint) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom,
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value 
 	from @results_database_schema.achilles_results
 	where analysis_id = 891) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/observation/sqlObservationTable.sql
+++ b/inst/sql/sql_server/export/observation/sqlObservationTable.sql
@@ -4,9 +4,9 @@ select concept.concept_id,
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 800 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 800 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 801 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 801 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/observation/sqlObservationTreemap.sql
+++ b/inst/sql/sql_server/export/observation/sqlObservationTreemap.sql
@@ -6,9 +6,9 @@ select 	concept_hierarchy.concept_id,
 	ar1.count_value as num_persons, 
 	1.0*ar1.count_value / denom.count_value as percent_persons,
 	1.0*ar2.count_value / ar1.count_value as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 800 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 800 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 801 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 801 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/observation/sqlObservationsByType.sql
+++ b/inst/sql/sql_server/export/observation/sqlObservationsByType.sql
@@ -4,7 +4,7 @@ select c1.concept_id as OBSERVATION_CONCEPT_ID,
 	c2.concept_name as CONCEPT_NAME, 
 	ar1.count_value as COUNT_VALUE
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 805
   GROUP BY analysis_id, stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/observation/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/observation/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 804
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/observation/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/observation/sqlPrevalenceByMonth.sql
@@ -3,8 +3,8 @@ select c1.concept_id as CONCEPT_ID,  --all rows for all concepts, but you may sp
 	num.stratum_2 as X_CALENDAR_MONTH,   -- calendar year, note, there could be blanks
 	round(1000*(1.0*num.count_value/denom.count_value),5) as Y_PREVALENCE_1000PP  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 802 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 802 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 

--- a/inst/sql/sql_server/export/observationperiod/ageatfirst.sql
+++ b/inst/sql/sql_server/export/observationperiod/ageatfirst.sql
@@ -1,4 +1,4 @@
-select cast(ar1.stratum_1 as int) as interval_index, 
+select cast(ar1.stratum_1 as bigint) as interval_index, 
 	ar1.count_value as count_value, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_value
 from 

--- a/inst/sql/sql_server/export/observationperiod/agebygender.sql
+++ b/inst/sql/sql_server/export/observationperiod/agebygender.sql
@@ -7,7 +7,7 @@ select c1.concept_name as Category,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 104
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/observationperiod/cumulativeduration.sql
+++ b/inst/sql/sql_server/export/observationperiod/cumulativeduration.sql
@@ -1,10 +1,10 @@
 select 'Length of observation' as series_name, 
 	ar1.stratum_1*30 as x_length_of_observation, 
 	round(1.0*sum(ar2.count_value) / denom.count_value,5) as y_percent_persons
-from (select analysis_id, cast(stratum_1 as int) stratum_1 from @results_database_schema.achilles_results where analysis_id = 108 GROUP BY analysis_id, stratum_1) ar1
+from (select analysis_id, cast(stratum_1 as bigint) stratum_1 from @results_database_schema.achilles_results where analysis_id = 108 GROUP BY analysis_id, stratum_1) ar1
 inner join
 (
-	select analysis_id, cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 108 GROUP BY analysis_id, stratum_1, count_value
+	select analysis_id, cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 108 GROUP BY analysis_id, stratum_1, count_value
 ) ar2 on ar1.analysis_id = ar2.analysis_id and ar1.stratum_1 <= ar2.stratum_1,
 (
 	select count_value from @results_database_schema.achilles_results where analysis_id = 1

--- a/inst/sql/sql_server/export/observationperiod/observationlength_data.sql
+++ b/inst/sql/sql_server/export/observationperiod/observationlength_data.sql
@@ -1,4 +1,4 @@
-select cast(ar1.stratum_1 as int) as interval_index, 
+select cast(ar1.stratum_1 as bigint) as interval_index, 
 	ar1.count_value as count_value, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_value
 from @results_database_schema.ACHILLES_analysis aa1

--- a/inst/sql/sql_server/export/observationperiod/observationlength_stats.sql
+++ b/inst/sql/sql_server/export/observationperiod/observationlength_stats.sql
@@ -1,5 +1,5 @@
-select  min(cast(ar1.stratum_1 as int)) * 30 as min_value, 
-	max(cast(ar1.stratum_1 as int)) * 30 as max_value, 
+select  min(cast(ar1.stratum_1 as bigint)) * 30 as min_value, 
+	max(cast(ar1.stratum_1 as bigint)) * 30 as max_value, 
 	30 as interval_size
 from @results_database_schema.ACHILLES_analysis aa1
 inner join @results_database_schema.achilles_results ar1 on aa1.analysis_id = ar1.analysis_id,

--- a/inst/sql/sql_server/export/observationperiod/observationlengthbyage.sql
+++ b/inst/sql/sql_server/export/observationperiod/observationlengthbyage.sql
@@ -1,4 +1,4 @@
- select concat(cast(cast(ard1.stratum_1 as int)*10 as varchar), '-', cast((cast(ard1.stratum_1 as int)+1)*10-1 as varchar))  as category,
+ select concat(cast(cast(ard1.stratum_1 as bigint)*10 as varchar), '-', cast((cast(ard1.stratum_1 as bigint)+1)*10-1 as varchar))  as category,
   ard1.min_value as min_value,
   ard1.p10_value as p10_value,
   ard1.p25_value as p25_value,

--- a/inst/sql/sql_server/export/observationperiod/observationlengthbygender.sql
+++ b/inst/sql/sql_server/export/observationperiod/observationlengthbygender.sql
@@ -7,7 +7,7 @@ select c1.concept_name as category,
   ard1.p90_value as p90_value,
   ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 106
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/observationperiod/observedbymonth.sql
+++ b/inst/sql/sql_server/export/observationperiod/observedbymonth.sql
@@ -1,7 +1,7 @@
 select ar1.stratum_1 as month_year, 
   ar1.count_value as count_value, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_value
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 110 GROUP BY analysis_id, stratum_1, count_value) ar1,
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 110 GROUP BY analysis_id, stratum_1, count_value) ar1,
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom
 
   

--- a/inst/sql/sql_server/export/observationperiod/observedbyyear_data.sql
+++ b/inst/sql/sql_server/export/observationperiod/observedbyyear_data.sql
@@ -1,4 +1,4 @@
-select cast(ar1.stratum_1 as int) - MinValue.MinValue as interval_index, 
+select cast(ar1.stratum_1 as bigint) - MinValue.MinValue as interval_index, 
   ar1.count_value as count_value, 
   round(1.0*ar1.count_value / denom.count_value,5) as percent_value
 from 
@@ -6,7 +6,7 @@ from
 	select * from @results_database_schema.achilles_results where analysis_id = 109
 ) ar1,
 (
-	select min(cast(stratum_1 as int)) as MinValue 
+	select min(cast(stratum_1 as bigint)) as MinValue 
 	from @results_database_schema.achilles_results where analysis_id = 109
 ) MinValue,
 (

--- a/inst/sql/sql_server/export/observationperiod/observedbyyear_stats.sql
+++ b/inst/sql/sql_server/export/observationperiod/observedbyyear_stats.sql
@@ -1,5 +1,5 @@
-select min(cast(ar1.stratum_1 as int)) as min_value,
-  max(cast(ar1.stratum_1 as int)) as max_value,
+select min(cast(ar1.stratum_1 as bigint)) as min_value,
+  max(cast(ar1.stratum_1 as bigint)) as max_value,
   1 as interval_size
 from @results_database_schema.achilles_results ar1
 where ar1.analysis_id = 109

--- a/inst/sql/sql_server/export/person/ethnicity.sql
+++ b/inst/sql/sql_server/export/person/ethnicity.sql
@@ -2,7 +2,7 @@ select c1.concept_id as concept_id,
   c1.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, count_value
+  select cast(stratum_1 as bigint) stratum_1, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 5
   GROUP BY analysis_id, stratum_1, count_value

--- a/inst/sql/sql_server/export/person/gender.sql
+++ b/inst/sql/sql_server/export/person/gender.sql
@@ -2,7 +2,7 @@ select c1.concept_id as concept_id,
   c1.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, count_value
+  select cast(stratum_1 as bigint) stratum_1, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 2 
   GROUP BY analysis_id, stratum_1, count_value

--- a/inst/sql/sql_server/export/person/population_age_gender.sql
+++ b/inst/sql/sql_server/export/person/population_age_gender.sql
@@ -3,8 +3,8 @@ select c1.concept_id as concept_id,
   	ar1.stratum_2 as age,
 	  ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1,
-	cast(stratum_2 as int) stratum_2, 
+  select cast(stratum_1 as bigint) stratum_1,
+	cast(stratum_2 as bigint) stratum_2, 
 	count_value
   from @results_database_schema.achilles_results
   where analysis_id = 102

--- a/inst/sql/sql_server/export/person/race.sql
+++ b/inst/sql/sql_server/export/person/race.sql
@@ -2,7 +2,7 @@ select c1.concept_id as concept_id,
   c1.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, count_value
+  select cast(stratum_1 as bigint) stratum_1, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 4
   GROUP BY analysis_id, stratum_1, count_value

--- a/inst/sql/sql_server/export/person/yearofbirth.sql
+++ b/inst/sql/sql_server/export/person/yearofbirth.sql
@@ -1,3 +1,3 @@
-select cast(ar.stratum_1 as int) as year, count_value as count_person
+select cast(ar.stratum_1 as bigint) as year, count_value as count_person
 from @results_database_schema.achilles_results ar
 where ar.analysis_id = 3

--- a/inst/sql/sql_server/export/person/yearofbirth_data.sql
+++ b/inst/sql/sql_server/export/person/yearofbirth_data.sql
@@ -1,7 +1,7 @@
 select ar1.stratum_1 - MinValue.MinValue as interval_index, 
   ar1.count_value as count_value, 
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_value
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 3 GROUP BY analysis_id, stratum_1, count_value) ar1,
-	(select min(cast(stratum_1 as int)) as MinValue from @results_database_schema.achilles_results where analysis_id = 3) MinValue,
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 3 GROUP BY analysis_id, stratum_1, count_value) ar1,
+	(select min(cast(stratum_1 as bigint)) as MinValue from @results_database_schema.achilles_results where analysis_id = 3) MinValue,
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom
 order by ar1.stratum_1 asc

--- a/inst/sql/sql_server/export/person/yearofbirth_stats.sql
+++ b/inst/sql/sql_server/export/person/yearofbirth_stats.sql
@@ -1,5 +1,5 @@
-select min(cast(ar1.stratum_1 as int)) as min_value,
-  max(cast(ar1.stratum_1 as int)) as max_value,
+select min(cast(ar1.stratum_1 as bigint)) as min_value,
+  max(cast(ar1.stratum_1 as bigint)) as max_value,
 	1 as interval_size
 from @results_database_schema.achilles_results ar1
 where ar1.analysis_id = 3

--- a/inst/sql/sql_server/export/procedure/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export/procedure/sqlAgeAtFirstOccurrence.sql
@@ -8,7 +8,7 @@
   	ard1.p90_value as p90_value,
   	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 606
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/procedure/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export/procedure/sqlFrequencyDistribution.sql
@@ -1,10 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as bigint) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom,
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value 
 	from @results_database_schema.achilles_results
 	where analysis_id = 691) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export/procedure/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/procedure/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 604
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/procedure/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/procedure/sqlPrevalenceByMonth.sql
@@ -3,9 +3,9 @@
   	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
   	round(1000*(1.0*num.count_value/denom.count_value),5) as y_prevalence_1000pp  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 602 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 602 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-	(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value)
+	(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value)
 	denom on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 ORDER BY num.stratum_2

--- a/inst/sql/sql_server/export/procedure/sqlProcedureTable.sql
+++ b/inst/sql/sql_server/export/procedure/sqlProcedureTable.sql
@@ -4,9 +4,9 @@ select concept.concept_id,
 	round(1.0*ar1.count_value / denom.count_value,5) as percent_persons,
 	round(1.0*ar2.count_value / ar1.count_value,5) as records_per_person
 from 
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 600 GROUP BY analysis_id, stratum_1, count_value) ar1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 600 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 601 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 601 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/procedure/sqlProcedureTreemap.sql
+++ b/inst/sql/sql_server/export/procedure/sqlProcedureTreemap.sql
@@ -6,9 +6,9 @@ select 	concept_hierarchy.concept_id,
 	ar1.count_value as num_persons, 
 	1.0*ar1.count_value / denom.count_value as percent_persons,
 	1.0*ar2.count_value / ar1.count_value as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 600 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 600 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 601 GROUP BY analysis_id, stratum_1, count_value) ar2
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 601 GROUP BY analysis_id, stratum_1, count_value) ar2
 	on ar1.stratum_1 = ar2.stratum_1
 	inner join
 	(

--- a/inst/sql/sql_server/export/procedure/sqlProceduresByType.sql
+++ b/inst/sql/sql_server/export/procedure/sqlProceduresByType.sql
@@ -4,7 +4,7 @@ select c1.concept_id as procedure_concept_id,
 	c2.concept_name as concept_name, 
 	ar1.count_value as count_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, count_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, count_value
   from @results_database_schema.achilles_results
   where analysis_id = 605
   GROUP BY analysis_id, stratum_1, stratum_2, count_value

--- a/inst/sql/sql_server/export/visit/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export/visit/sqlAgeAtFirstOccurrence.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, cast(stratum_2 as int) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, cast(stratum_2 as bigint) stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 206
   GROUP BY analysis_id, stratum_1, stratum_2, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/visit/sqlDomainVisitStratification.sql
+++ b/inst/sql/sql_server/export/visit/sqlDomainVisitStratification.sql
@@ -1,4 +1,4 @@
 select stratum_1 concept_id, concept_name, stratum_2 cdm_table_name, count_value record_count 
 from @results_database_schema.achilles_results ar
-join @vocab_database_schema.concept c on c.concept_id = cast(ar.stratum_1 as int)
+join @vocab_database_schema.concept c on c.concept_id = cast(ar.stratum_1 as bigint)
 where analysis_id = 226

--- a/inst/sql/sql_server/export/visit/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/visit/sqlPrevalenceByGenderAgeYear.sql
@@ -12,14 +12,14 @@ FROM (
 		num.count_value AS num_count_value,
 		denom.count_value AS denom_count_value
 	FROM (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 204
 			AND stratum_3 IN ('8507', '8532')
 		group by stratum_1, stratum_2, stratum_3, stratum_4, count_value
 		) num
 	INNER JOIN (
-    SELECT CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, CAST(stratum_3 as int) stratum_3, cast(stratum_4 as int) stratum_4, count_value
+    SELECT CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, CAST(stratum_3 as bigint) stratum_3, cast(stratum_4 as bigint) stratum_4, count_value
 		FROM @results_database_schema.achilles_results
 		WHERE analysis_id = 116
 			AND stratum_2 IN ('8507', '8532')

--- a/inst/sql/sql_server/export/visit/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/visit/sqlPrevalenceByMonth.sql
@@ -3,8 +3,8 @@ select c1.concept_id as concept_id,  --all rows for all concepts, but you may sp
 	num.stratum_2 as x_calendar_month,   -- calendar year, note, there could be blanks
 	1000*(1.0*num.count_value/denom.count_value) as y_prevalence_1000pp  --prevalence, per 1000 persons
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 202 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
+	(select CAST(stratum_1 as bigint) stratum_1, CAST(stratum_2 as bigint) stratum_2, count_value from @results_database_schema.achilles_results where analysis_id = 202 GROUP BY analysis_id, stratum_1, stratum_2, count_value) num
 	inner join
-		(select CAST(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
+		(select CAST(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 117 GROUP BY analysis_id, stratum_1, count_value) denom on num.stratum_2 = denom.stratum_1  --calendar year
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 

--- a/inst/sql/sql_server/export/visit/sqlVisitDurationByType.sql
+++ b/inst/sql/sql_server/export/visit/sqlVisitDurationByType.sql
@@ -8,7 +8,7 @@ select c1.concept_id as concept_id,
 	ard1.p90_value as p90_value,
 	ard1.max_value as max_value
 from (
-  select cast(stratum_1 as int) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
+  select cast(stratum_1 as bigint) stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value
   FROM @results_database_schema.achilles_results_dist
   where analysis_id = 213
   GROUP BY analysis_id, stratum_1, min_value, p10_value, p25_value, median_value, p75_value, p90_value, max_value 

--- a/inst/sql/sql_server/export/visit/sqlVisitTreemap.sql
+++ b/inst/sql/sql_server/export/visit/sqlVisitTreemap.sql
@@ -3,9 +3,9 @@ select 	c1.concept_id,
 	ar1.count_value as num_persons, 
 	1.0*ar1.count_value / denom.count_value as percent_persons,
 	1.0*ar2.count_value / ar1.count_value as records_per_person
-from (select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 200 GROUP BY analysis_id, stratum_1, count_value) ar1
+from (select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 200 GROUP BY analysis_id, stratum_1, count_value) ar1
 	inner join
-	(select cast(stratum_1 as int) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 201 GROUP BY analysis_id, stratum_1, count_value) ar2 on ar1.stratum_1 = ar2.stratum_1
+	(select cast(stratum_1 as bigint) stratum_1, count_value from @results_database_schema.achilles_results where analysis_id = 201 GROUP BY analysis_id, stratum_1, count_value) ar2 on ar1.stratum_1 = ar2.stratum_1
 	inner join @vocab_database_schema.concept c1 on ar1.stratum_1 = c1.concept_id,
 	(select count_value from @results_database_schema.achilles_results where analysis_id = 1) denom
 

--- a/inst/sql/sql_server/export/visit/sqlVisitTreemapAO.sql
+++ b/inst/sql/sql_server/export/visit/sqlVisitTreemapAO.sql
@@ -4,21 +4,21 @@ SELECT c1.concept_id,
        1.0 *ar1.count_value / denom.count_value AS percent_persons,
        1.0 *ar2.count_value / ar1.count_value AS records_per_person,
        1.0 *ar3.avg_value AS average_duration
-FROM (SELECT CAST(stratum_1 AS INT) stratum_1,
+FROM (SELECT CAST(stratum_1 AS BIGINT) stratum_1,
              count_value
       FROM @results_database_schema.achilles_results
       WHERE analysis_id = 200
       GROUP BY analysis_id,
                stratum_1,
                count_value) ar1
-  INNER JOIN (SELECT CAST(stratum_1 AS INT) stratum_1,
+  INNER JOIN (SELECT CAST(stratum_1 AS BIGINT) stratum_1,
                      count_value
               FROM @results_database_schema.achilles_results
               WHERE analysis_id = 201
               GROUP BY analysis_id,
                        stratum_1,
                        count_value) ar2 ON ar1.stratum_1 = ar2.stratum_1
-  INNER JOIN (SELECT CAST(stratum_1 AS INT) stratum_1,avg_value
+  INNER JOIN (SELECT CAST(stratum_1 AS BIGINT) stratum_1,avg_value
               FROM @results_database_schema.achilles_results_dist
               WHERE analysis_id = 213
               GROUP BY analysis_id,

--- a/inst/sql/sql_server/export/visitdetail/sqlAgeAtFirstOccurrence.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlAgeAtFirstOccurrence.sql
@@ -10,8 +10,8 @@ SELECT
 	ard.max_value AS max_value
 FROM (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
-		CAST(stratum_2 AS INT) stratum_2,
+		CAST(stratum_1 AS BIGINT) stratum_1,
+		CAST(stratum_2 AS BIGINT) stratum_2,
 		min_value,
 		p10_value,
 		p25_value,

--- a/inst/sql/sql_server/export/visitdetail/sqlDomainVisitDetailStratification.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlDomainVisitDetailStratification.sql
@@ -6,6 +6,6 @@ SELECT
 FROM 
 	@results_database_schema.achilles_results ar
 JOIN 
-	@vocab_database_schema.concept c ON c.concept_id = CAST(ar.stratum_1 AS INT)
+	@vocab_database_schema.concept c ON c.concept_id = CAST(ar.stratum_1 AS BIGINT)
 WHERE 
 	ar.analysis_id = 1326

--- a/inst/sql/sql_server/export/visitdetail/sqlPrevalenceByGenderAgeYear.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlPrevalenceByGenderAgeYear.sql
@@ -19,10 +19,10 @@ FROM (
 		denom.count_value AS denom_count_value
 	FROM (
 		SELECT 
-			CAST(stratum_1 AS INT) stratum_1,
-			CAST(stratum_2 AS INT) stratum_2,
-			CAST(stratum_3 AS INT) stratum_3,
-			CAST(stratum_4 AS INT) stratum_4,
+			CAST(stratum_1 AS BIGINT) stratum_1,
+			CAST(stratum_2 AS BIGINT) stratum_2,
+			CAST(stratum_3 AS BIGINT) stratum_3,
+			CAST(stratum_4 AS BIGINT) stratum_4,
 			count_value
 		FROM 
 			@results_database_schema.achilles_results
@@ -38,10 +38,10 @@ FROM (
 		) num
 	JOIN (
 		SELECT 
-			CAST(stratum_1 AS INT) stratum_1,
-			CAST(stratum_2 AS INT) stratum_2,
-			CAST(stratum_3 AS INT) stratum_3,
-			CAST(stratum_4 AS INT) stratum_4,
+			CAST(stratum_1 AS BIGINT) stratum_1,
+			CAST(stratum_2 AS BIGINT) stratum_2,
+			CAST(stratum_3 AS BIGINT) stratum_3,
+			CAST(stratum_4 AS BIGINT) stratum_4,
 			count_value
 		FROM 
 			@results_database_schema.achilles_results

--- a/inst/sql/sql_server/export/visitdetail/sqlPrevalenceByMonth.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlPrevalenceByMonth.sql
@@ -5,8 +5,8 @@ SELECT
 	1000 * (1.0 * num.count_value / denom.count_value) AS y_prevalence_1000pp --prevalence, per 1000 persons
 FROM (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
-		CAST(stratum_2 AS INT) stratum_2,
+		CAST(stratum_1 AS BIGINT) stratum_1,
+		CAST(stratum_2 AS BIGINT) stratum_2,
 		count_value
 	FROM 
 		@results_database_schema.achilles_results
@@ -20,7 +20,7 @@ FROM (
 	) num
 JOIN (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
+		CAST(stratum_1 AS BIGINT) stratum_1,
 		count_value
 	FROM 
 		@results_database_schema.achilles_results

--- a/inst/sql/sql_server/export/visitdetail/sqlVisitDetailDurationByType.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlVisitDetailDurationByType.sql
@@ -10,7 +10,7 @@ SELECT
 	ard1.max_value AS max_value
 FROM (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
+		CAST(stratum_1 AS BIGINT) stratum_1,
 		min_value,
 		p10_value,
 		p25_value,

--- a/inst/sql/sql_server/export/visitdetail/sqlVisitDetailTreemap.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlVisitDetailTreemap.sql
@@ -6,7 +6,7 @@ SELECT
 	1.0 * ar2.count_value / ar1.count_value AS records_per_person
 FROM (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
+		CAST(stratum_1 AS BIGINT) stratum_1,
 		count_value
 	FROM 
 		@results_database_schema.achilles_results
@@ -19,7 +19,7 @@ FROM (
 	) ar1
 JOIN (
 	SELECT 
-		CAST(stratum_1 AS INT) stratum_1,
+		CAST(stratum_1 AS BIGINT) stratum_1,
 		count_value
 	FROM 
 		@results_database_schema.achilles_results

--- a/inst/sql/sql_server/export/visitdetail/sqlVisitDetailTreemapAO.sql
+++ b/inst/sql/sql_server/export/visitdetail/sqlVisitDetailTreemapAO.sql
@@ -4,21 +4,21 @@ SELECT c1.concept_id,
        1.0 *ar1.count_value / denom.count_value AS percent_persons,
        1.0 *ar2.count_value / ar1.count_value AS records_per_person,
        1.0 *ar3.avg_value AS average_duration
-FROM (SELECT CAST(stratum_1 AS INT) stratum_1,
+FROM (SELECT CAST(stratum_1 AS BIGINT) stratum_1,
              count_value
       FROM @results_database_schema.achilles_results
       WHERE analysis_id = 1300
       GROUP BY analysis_id,
                stratum_1,
                count_value) ar1
-  JOIN (SELECT CAST(stratum_1 AS INT) stratum_1,
+  JOIN (SELECT CAST(stratum_1 AS BIGINT) stratum_1,
                count_value
         FROM @results_database_schema.achilles_results
         WHERE analysis_id = 1301
         GROUP BY analysis_id,
                  stratum_1,
                  count_value) ar2 ON ar1.stratum_1 = ar2.stratum_1
-                   INNER JOIN (SELECT CAST(stratum_1 AS INT) stratum_1,avg_value
+                   INNER JOIN (SELECT CAST(stratum_1 AS BIGINT) stratum_1,avg_value
               FROM @results_database_schema.achilles_results_dist
               WHERE analysis_id = 1313
               GROUP BY analysis_id,


### PR DESCRIPTION
Lots of changes, hopefully I didn't miss any.  : )
According to online doc, sql server, postgresql, redshift, sqlite, and netezza, all support bigint natively.
Oracle, hive, bigquery, and impala, are supported via sqlrender.

Tested successfully on Redshift against cdm v5.3:

```r
Achilles::exportToJson(
  connectionDetails = connectionDetails,
  cdmDatabaseSchema = cdmDatabaseSchema,
  resultsDatabaseSchema = resultsDatabaseSchema,
  vocabDatabaseSchema = cdmDatabaseSchema,
  outputPath = your_output_dir
)

```