### PR TITLE
Fixes #657

### DIFF
--- a/inst/sql/sql_server/analyses/achilles_analysis_ddl.sql
+++ b/inst/sql/sql_server/analyses/achilles_analysis_ddl.sql
@@ -1,0 +1,18 @@
+
+-- DDL FOR THE ACHILLES_ANALYSIS TABLE
+
+IF OBJECT_ID('@resultsDatabaseSchema.achilles_analysis', 'U') IS NOT NULL
+  DROP TABLE @resultsDatabaseSchema.achilles_analysis;
+  
+CREATE TABLE @resultsDatabaseSchema.ACHILLES_ANALYSIS (
+	analysis_id     INTEGER,
+	analysis_name   VARCHAR(255),
+	stratum_1_name  VARCHAR(255),
+	stratum_2_name  VARCHAR(255),
+	stratum_3_name  VARCHAR(255),
+	stratum_4_name  VARCHAR(255),
+	stratum_5_name  VARCHAR(255),
+	is_default      INTEGER,
+	category        VARCHAR(255)
+);
+


### PR DESCRIPTION
To address this issue, the fix creates the achilles_analysis table from a pre-existing sql script, rather than generate it dynamically using CTAS and union-all.  The table is populated using the data from the achilles_analysis_details.csv.  This was successfully tested against cdm v5.3 on redshift.  To test:

```r

# Run achilles for all analyses
Achilles::achilles(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema,
                   cdmVersion = "5.3")

# After deleting some analyses, runMissingAnalyses
Achilles::runMissingAnalyses(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema)

# Update only
Achilles::achilles(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema,
                   cdmVersion = "5.3",
                   updateGivenAnalysesOnly = T,
                   createTable = F,
                   analysisIds = c(402,702))

# Exclude certain analyses
Achilles::achilles(connectionDetails = connectionDetails,
                   cdmDatabaseSchema = cdmDatabaseSchema,
                   resultsDatabaseSchema = resultsDatabaseSchema,
                   cdmVersion = "5.3",
                   excludeAnalysisIds = c(402,702))
```

The above scenarios all ran without error.