### PR TITLE
Removed NUMERIC(7,6) from analysis 532

### DIFF
--- a/inst/sql/sql_server/analyses/532.sql
+++ b/inst/sql/sql_server/analyses/532.sql
@@ -30,7 +30,7 @@ FROM
 SELECT 
 	532 AS analysis_id,
 	CASE WHEN dt.record_count != 0 THEN
-		CAST(CAST(1.0*op.record_count/dt.record_count AS NUMERIC(7,6)) AS VARCHAR(255)) 
+		CAST(CAST(1.0*op.record_count/dt.record_count AS FLOAT) AS VARCHAR(255)) 
 	ELSE 
 		CAST(NULL AS VARCHAR(255))
 	END AS stratum_1, 


### PR DESCRIPTION
Fixes #691 

I had recently removed this from other analyses (casting to FLOAT instead), but must have missed 532.

