### PR TITLE
Fix failure on missing server value in getTemporalData

### DIFF
--- a/R/getTemporalData.r
+++ b/R/getTemporalData.r
@@ -93,9 +93,13 @@ getTemporalData <- function(connectionDetails,
     analysisIdGiven <- FALSE
   }
 
-  if (typeof(connectionDetails$server) == "character")
-    dbName <- toupper(strsplit(connectionDetails$server,
-                               "/")[[1]][2]) else dbName <- toupper(strsplit(connectionDetails$server(), "/")[[1]][2])
+  if (typeof(connectionDetails$server) == "character") {
+    dbName <- toupper(strsplit(connectionDetails$server, "/")[[1]][2])
+  } else if (typeof(connectionDetails$server()) == "character") {
+    dbName <- toupper(strsplit(connectionDetails$server(), "/")[[1]][2])
+  } else {
+    dbName <- NA
+  }
 
   translatedSql <- SqlRender::loadRenderTranslateSql(sqlFilename = "temporal/achilles_temporal_data.sql",
     packageName = "Achilles", dbms = connectionDetails$dbms, db_name = dbName, cdm_schema = cdmDatabaseSchema,


### PR DESCRIPTION
When connection details is set up using Connection String, server value is NULL. It caused failure on attempt to extract dbName from server.
Now, dbName is set to NA if server is not provided (new behavior) as well as when it doesn't contain slash character ("/") (existent behavior)