### PR TITLE
Fix #801: Use list() instead of c() to preserve integer type in performanceTable

### DIFF
--- a/R/Achilles.R
+++ b/R/Achilles.R
@@ -456,7 +456,7 @@ achilles <- function(connectionDetails,
           endTime <- Sys.time()
           delta <- endTime - start
           analysisId <- as.integer(mainSql$analysisId)
-          performanceTable[nrow(performanceTable) + 1, ] <- c(analysisId, delta, start, endTime)
+          performanceTable[nrow(performanceTable) + 1, ] <- list(analysisId, delta, start, endTime)
           ParallelLogger::logInfo(sprintf(
             "[Main Analysis] [COMPLETE] %d (%f %s)",
             as.integer(mainSql$analysisId),


### PR DESCRIPTION
Fixes #801

**Problem**
BigQuery rejects `achilles_performance` insert because `analysis_id` is sent as FLOAT64 instead of INT64, returning error:
```
Error in rJava::.jcall(batchedInsert, "Z", "executeBatch") :
java.sql.SQLException: [Simba][JDBC](11680) Cannot use rollback while Connection is in auto-commit mode.
```

**Root Cause**
Line 459 uses `c()` which coerces all elements to the same type. Since `delta`, `start`, and `endTime` are
numeric (double), `c()` converts the integer `analysisId` to numeric.
```
performanceTable[nrow(performanceTable) + 1, ] <- c(analysisId, delta, start, endTime)
```

**Solution**
Changed `c()` to `list()` which preserves each element's original type.
```
performanceTable[nrow(performanceTable) + 1, ] <- list(analysisId, delta, start, endTime)
```

Tested and confirmed working on BigQuery with DatabaseConnector v7.0.0.